### PR TITLE
From fallback

### DIFF
--- a/src/transaction/quai-transaction.ts
+++ b/src/transaction/quai-transaction.ts
@@ -443,7 +443,7 @@ export class QuaiTransaction extends AbstractTransaction<Signature> implements Q
         }
 
         if (tx.from != null) {
-            validateAddress(tx.from);
+            assertArgument(!isQiAddress(tx.from), 'from address must be a Quai address', 'tx.from', tx.from);
             assertArgument(
                 (result.from || '').toLowerCase() === (tx.from || '').toLowerCase(),
                 'from mismatch',

--- a/src/wallet/base-wallet.ts
+++ b/src/wallet/base-wallet.ts
@@ -89,27 +89,26 @@ export class BaseWallet extends AbstractSigner {
             from: tx.from ? resolveAddress(tx.from) : undefined,
         });
 
-        if (to != null) {
+        if (to !== undefined) {
             validateAddress(to);
             tx.to = to;
         }
-        if (from != null) {
-            validateAddress(from);
-            tx.from = from;
-        }
 
-        if (tx.from != null) {
+        if (from !== undefined) {
             assertArgument(
-                getAddress(<string>tx.from) === this.#address,
+                getAddress(<string>from) === this.#address,
                 'transaction from address mismatch',
                 'tx.from',
-                tx.from,
+                from,
             );
+        } else {
+            // No `from` specified, use the wallet's address
+            tx.from = this.#address;
         }
 
         const btx = QuaiTransaction.from(<QuaiTransactionLike>tx);
-        const digest= keccak256(btx.unsignedSerialized)
-        btx.signature = this.signingKey.sign(digest)
+        const digest = keccak256(btx.unsignedSerialized);
+        btx.signature = this.signingKey.sign(digest);
 
         return btx.serialized;
     }


### PR DESCRIPTION
- When signing a tx with a `BaseWallet` or `Wallet` instance, fallback to populating `tx.from` field with wallet address
- Remove Qi logic from `AbstractSigner` because the `AbstractSigner` is only for ECDSA (aka Quai not Qi)
- Check that the `from` address on a `QuaiTransaction` instance is actually a valid Quai address