### PR TITLE
add new method: signTypedData()

### DIFF
--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -280,9 +280,24 @@ export abstract class AbstractHDWallet {
         return changeNode.deriveChild(addressInfo.index);
     }
 
+    /**
+     * Abstract method to sign a message using the private key associated with the given address.
+     *
+     * @param {string} address - The address for which the message is to be signed.
+     * @param {string | Uint8Array} message - The message to be signed, either as a string or Uint8Array.
+     *
+     * @returns {Promise<string>} A promise that resolves to the signature of the message in hexadecimal string format.
+     * @throws {Error} If the method is not implemented in the subclass.
+     */
     abstract signMessage(address: string, message: string | Uint8Array): Promise<string>;
 
-    public async serialize(): Promise<SerializedHDWallet> {
+    /**
+     * Serializes the HD wallet state into a format suitable for storage or transmission.
+     *
+     * @returns {SerializedHDWallet} An object representing the serialized state of the HD wallet, including version,
+     *   mnemonic phrase, coin type, and addresses.
+     */
+    public serialize(): SerializedHDWallet {
         const addresses = Array.from(this._addresses.values());
         return {
             version: (this.constructor as any)._version,
@@ -292,12 +307,28 @@ export abstract class AbstractHDWallet {
         };
     }
 
+    /**
+     * Deserializes a serialized HD wallet object and reconstructs the wallet instance. This method must be implemented
+     * in the subclass.
+     *
+     * @param {SerializedHDWallet} _serialized - The serialized object representing the state of an HD wallet.
+     *
+     * @returns {AbstractHDWallet} An instance of AbstractHDWallet.
+     * @throws {Error} This method must be implemented in the subclass.
+     */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public static async deserialize(_serialized: SerializedHDWallet): Promise<AbstractHDWallet> {
         throw new Error('deserialize method must be implemented in the subclass');
     }
 
-    // This method is used to validate the version and coinType of the serialized wallet.
+    /**
+     * Validates the version and coinType of the serialized wallet.
+     *
+     * @param {SerializedHDWallet} serialized - The serialized wallet data to be validated.
+     * @throws {Error} If the version or coinType of the serialized wallet does not match the expected values.
+     * @protected
+     * @static
+     */
     protected static validateSerializedWallet(serialized: SerializedHDWallet): void {
         if (serialized.version !== (this as any)._version) {
             throw new Error(`Invalid version ${serialized.version} for wallet (expected ${(this as any)._version})`);
@@ -307,9 +338,16 @@ export abstract class AbstractHDWallet {
         }
     }
 
-    // This method is used to import addresses from a serialized wallet into the addresses map.
-    // Before adding the addresses, a validation is performed to ensure the address, public key and zone
-    // match the expected values.
+    /**
+     * Imports addresses from a serialized wallet into the addresses map. Before adding the addresses, a validation is
+     * performed to ensure the address, public key, and zone match the expected values.
+     *
+     * @param {Map<string, NeuteredAddressInfo>} addressMap - The map where the addresses will be imported.
+     * @param {NeuteredAddressInfo[]} addresses - The array of addresses to be imported, each containing account, index,
+     *   change, address, pubKey, and zone information.
+     * @throws {Error} If there is a mismatch between the expected and actual address, public key, or zone.
+     * @protected
+     */
     protected importSerializedAddresses(
         addressMap: Map<string, NeuteredAddressInfo>,
         addresses: NeuteredAddressInfo[],

--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -251,8 +251,19 @@ export abstract class AbstractHDWallet {
         }
     }
 
-    // Returns the HD node that derives the address.
-    // If the address is not found in the wallet, an error is thrown.
+    /**
+     * Derives and returns the Hierarchical Deterministic (HD) node wallet associated with a given address.
+     *
+     * This method fetches the account and address information from the wallet's internal storage, derives the
+     * appropriate change node based on whether the address is a change address, and further derives the final HD node
+     * using the address index.
+     *
+     * @param {string} addr - The address for which to derive the HD node.
+     *
+     * @returns {HDNodeWallet} - The derived HD node wallet corresponding to the given address.
+     * @throws {Error} If the given address is not known to the wallet.
+     * @throws {Error} If the account associated with the address is not found.
+     */
     protected _getHDNodeForAddress(addr: string): HDNodeWallet {
         const addressInfo = this._addresses.get(addr);
         if (!addressInfo) {

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -321,6 +321,15 @@ export class QiHDWallet extends AbstractHDWallet {
         return gapChangeAddresses;
     }
 
+    /**
+     * Signs a message using the private key associated with the given address.
+     *
+     * @param {string} address - The address for which the message is to be signed.
+     * @param {string | Uint8Array} message - The message to be signed, either as a string or Uint8Array.
+     *
+     * @returns {Promise<string>} A promise that resolves to the signature of the message in hexadecimal string format.
+     * @throws {Error} If the address does not correspond to a valid HD node or if signing fails.
+     */
     public async signMessage(address: string, message: string | Uint8Array): Promise<string> {
         const addrNode = this._getHDNodeForAddress(address);
         const privKey = addrNode.privateKey;
@@ -329,8 +338,14 @@ export class QiHDWallet extends AbstractHDWallet {
         return hexlify(signature);
     }
 
-    public async serialize(): Promise<SerializedQiHDWallet> {
-        const hdwalletSerialized = await super.serialize();
+    /**
+     * Serializes the HD wallet state into a format suitable for storage or transmission.
+     *
+     * @returns {SerializedQiHDWallet} An object representing the serialized state of the HD wallet, including
+     *   outpoints, change addresses, gap addresses, and other inherited properties.
+     */
+    public serialize(): SerializedQiHDWallet {
+        const hdwalletSerialized = super.serialize();
         return {
             outpoints: this._outpoints,
             changeAddresses: Array.from(this._changeAddresses.values()),
@@ -340,6 +355,15 @@ export class QiHDWallet extends AbstractHDWallet {
         };
     }
 
+    /**
+     * Deserializes a serialized QiHDWallet object and reconstructs the wallet instance.
+     *
+     * @param {SerializedQiHDWallet} serialized - The serialized object representing the state of a QiHDWallet.
+     *
+     * @returns {Promise<QiHDWallet>} A promise that resolves to a reconstructed QiHDWallet instance.
+     * @throws {Error} If the serialized data is invalid or if any addresses in the gap addresses or gap change
+     *   addresses do not exist in the wallet.
+     */
     public static async deserialize(serialized: SerializedQiHDWallet): Promise<QiHDWallet> {
         super.validateSerializedWallet(serialized);
         // create the wallet instance
@@ -376,6 +400,20 @@ export class QiHDWallet extends AbstractHDWallet {
         return wallet;
     }
 
+    /**
+     * Validates an array of OutpointInfo objects.
+     *
+     * This method checks the validity of each OutpointInfo object by performing the following validations:
+     *
+     * - Validates the zone using the `validateZone` method.
+     * - Checks if the address exists in the wallet.
+     * - Checks if the account (if provided) exists in the wallet.
+     * - Validates the Outpoint by ensuring that `Txhash`, `Index`, and `Denomination` are not null.
+     *
+     * @private
+     * @param {OutpointInfo[]} outpointInfo - An array of OutpointInfo objects to be validated.
+     * @throws {Error} If any of the validations fail, an error is thrown with a descriptive message.
+     */
     private validateOutpointInfo(outpointInfo: OutpointInfo[]): void {
         outpointInfo.forEach((info) => {
             // validate zone

--- a/src/wallet/quai-hdwallet.ts
+++ b/src/wallet/quai-hdwallet.ts
@@ -3,11 +3,12 @@ import { HDNodeWallet } from './hdnodewallet.js';
 import { QuaiTransactionRequest, Provider, TransactionResponse } from '../providers/index.js';
 import { resolveAddress } from '../address/index.js';
 import { AllowedCoinType } from '../constants/index.js';
+import { SerializedHDWallet } from './hdwallet.js';
+import { Mnemonic } from './mnemonic.js';
 
 export class QuaiHDWallet extends AbstractHDWallet {
-
     protected static _version: number = 1;
-    
+
     protected static _coinType: AllowedCoinType = 994;
 
     private constructor(root: HDNodeWallet, provider?: Provider) {
@@ -31,8 +32,22 @@ export class QuaiHDWallet extends AbstractHDWallet {
         return await fromNodeConnected.sendTransaction(tx);
     }
 
-    public async signMessage(address: string, message: string | Uint8Array): Promise<string> { 
+    public async signMessage(address: string, message: string | Uint8Array): Promise<string> {
         const addrNode = this._getHDNodeForAddress(address);
         return await addrNode.signMessage(message);
+    }
+
+    public static async deserialize(serialized: SerializedHDWallet): Promise<QuaiHDWallet> {
+        super.validateSerializedWallet(serialized);
+        // create the wallet instance
+        const mnemonic = Mnemonic.fromPhrase(serialized.phrase);
+        const path = (this as any).parentPath(serialized.coinType);
+        const root = HDNodeWallet.fromMnemonic(mnemonic, path);
+        const wallet = new this(root);
+
+        // import the addresses
+        wallet.importSerializedAddresses(wallet._addresses, serialized.addresses);
+
+        return wallet;
     }
 }

--- a/src/wallet/quai-hdwallet.ts
+++ b/src/wallet/quai-hdwallet.ts
@@ -5,6 +5,7 @@ import { resolveAddress } from '../address/index.js';
 import { AllowedCoinType } from '../constants/index.js';
 import { SerializedHDWallet } from './hdwallet.js';
 import { Mnemonic } from './mnemonic.js';
+import { TypedDataDomain, TypedDataField } from '../hash/index.js';
 
 export class QuaiHDWallet extends AbstractHDWallet {
     protected static _version: number = 1;
@@ -49,5 +50,27 @@ export class QuaiHDWallet extends AbstractHDWallet {
         wallet.importSerializedAddresses(wallet._addresses, serialized.addresses);
 
         return wallet;
+    }
+
+    /**
+     * Signs typed data using the private key associated with the given address.
+     *
+     * @param {string} address - The address for which the typed data is to be signed.
+     * @param {TypedDataDomain} domain - The domain information of the typed data, defining the scope of the signature.
+     * @param {Record<string, TypedDataField[]>} types - The types of the data to be signed, mapping each data type name
+     *   to its fields.
+     * @param {Record<string, unknown>} value - The actual data to be signed.
+     *
+     * @returns {Promise<string>} A promise that resolves to the signed data in string format.
+     * @throws {Error} If the address does not correspond to a valid HD node or if signing fails.
+     */
+    public async signTypedData(
+        address: string,
+        domain: TypedDataDomain,
+        types: Record<string, Array<TypedDataField>>,
+        value: Record<string, unknown>,
+    ): Promise<string> {
+        const addrNode = this._getHDNodeForAddress(address);
+        return addrNode.signTypedData(domain, types, value);
     }
 }

--- a/src/wallet/quai-hdwallet.ts
+++ b/src/wallet/quai-hdwallet.ts
@@ -38,6 +38,23 @@ export class QuaiHDWallet extends AbstractHDWallet {
         return await addrNode.signMessage(message);
     }
 
+    /**
+     * Deserializes the given serialized HD wallet data into an instance of QuaiHDWallet.
+     *
+     * This method performs the following steps:
+     *
+     * - Validates the serialized wallet data.
+     * - Creates a new wallet instance using the mnemonic phrase and derivation path.
+     * - Imports the addresses into the wallet instance.
+     *
+     * @async
+     * @param {SerializedHDWallet} serialized - The serialized wallet data to be deserialized.
+     *
+     * @returns {Promise<QuaiHDWallet>} A promise that resolves to an instance of QuaiHDWallet.
+     * @throws {Error} If validation of the serialized wallet data fails or if deserialization fails.
+     * @public
+     * @static
+     */
     public static async deserialize(serialized: SerializedHDWallet): Promise<QuaiHDWallet> {
         super.validateSerializedWallet(serialized);
         // create the wallet instance


### PR DESCRIPTION
This PR includes the following changes:
- static `deserialize` method is moved to child subclasses to eliminate cyclic dependencies with parent class
- QiHDWallet: adds a helper method to validate user imported outpoints
- QuaiHDWallet: adds new method `signTypedData`