### PR TITLE
Various wallet improvements

### DIFF
--- a/src/providers/abstract-provider.ts
+++ b/src/providers/abstract-provider.ts
@@ -1321,7 +1321,7 @@ export class AbstractProvider<C = FetchRequest> implements Provider {
             address,
             'latest',
         );
-        return outpoints.map((outpoint: OutpointResponseParams) => ({
+        return (outpoints ?? []).map((outpoint: OutpointResponseParams) => ({
             txhash: outpoint.Txhash,
             index: outpoint.Index,
             denomination: outpoint.Denomination,

--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -64,7 +64,7 @@ export abstract class AbstractHDWallet {
      * @param {number} startingIndex - The index from which to start deriving addresses.
      * @param {Zone} zone - The zone (shard) for which the address should be valid.
      * @param {boolean} [isChange=false] - Whether to derive a change address (default is false). Default is `false`
-     *   Default is `false`
+     *   Default is `false` Default is `false`
      *
      * @returns {HDNodeWallet} - The derived HD node wallet containing a valid address for the specified zone.
      * @throws {Error} If a valid address for the specified zone cannot be derived within the allowed attempts.
@@ -132,10 +132,29 @@ export abstract class AbstractHDWallet {
         return this.createAndStoreAddressInfo(addressNode, account, zone, isChange, addressMap);
     }
 
+    /**
+     * Retrieves the next address for the specified account and zone.
+     *
+     * @param {number} account - The index of the account for which to retrieve the next address.
+     * @param {Zone} zone - The zone in which to retrieve the next address.
+     *
+     * @returns {NeuteredAddressInfo} The next neutered address information.
+     */
     public getNextAddress(account: number, zone: Zone): NeuteredAddressInfo {
         return this._getNextAddress(account, zone, false, this._addresses);
     }
 
+    /**
+     * Derives and returns the next address information for the specified account and zone.
+     *
+     * @param {number} accountIndex - The index of the account for which the address is being generated.
+     * @param {Zone} zone - The zone in which the address is to be used.
+     * @param {boolean} isChange - A flag indicating whether the address is a change address.
+     * @param {Map<string, NeuteredAddressInfo>} addressMap - A map storing the neutered address information.
+     *
+     * @returns {NeuteredAddressInfo} The derived neutered address information.
+     * @throws {Error} If the zone is invalid.
+     */
     protected _getNextAddress(
         accountIndex: number,
         zone: Zone,

--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -64,6 +64,7 @@ export abstract class AbstractHDWallet {
      * @param {number} startingIndex - The index from which to start deriving addresses.
      * @param {Zone} zone - The zone (shard) for which the address should be valid.
      * @param {boolean} [isChange=false] - Whether to derive a change address (default is false). Default is `false`
+     *   Default is `false`
      *
      * @returns {HDNodeWallet} - The derived HD node wallet containing a valid address for the specified zone.
      * @throws {Error} If a valid address for the specified zone cannot be derived within the allowed attempts.
@@ -131,12 +132,20 @@ export abstract class AbstractHDWallet {
         return this.createAndStoreAddressInfo(addressNode, account, zone, isChange, addressMap);
     }
 
-    public getNextAddress(accountIndex: number, zone: Zone): NeuteredAddressInfo {
-        this.validateZone(zone);
-        const lastIndex = this.getLastAddressIndex(this._addresses, zone, accountIndex, false);
-        const addressNode = this.deriveNextAddressNode(accountIndex, lastIndex + 1, zone);
+    public getNextAddress(account: number, zone: Zone): NeuteredAddressInfo {
+        return this._getNextAddress(account, zone, false, this._addresses);
+    }
 
-        return this.createAndStoreAddressInfo(addressNode, accountIndex, zone, false, this._addresses);
+    protected _getNextAddress(
+        accountIndex: number,
+        zone: Zone,
+        isChange: boolean,
+        addressMap: Map<string, NeuteredAddressInfo>,
+    ): NeuteredAddressInfo {
+        this.validateZone(zone);
+        const lastIndex = this.getLastAddressIndex(addressMap, zone, accountIndex, isChange);
+        const addressNode = this.deriveNextAddressNode(accountIndex, lastIndex + 1, zone, isChange);
+        return this.createAndStoreAddressInfo(addressNode, accountIndex, zone, isChange, addressMap);
     }
 
     public getAddressInfo(address: string): NeuteredAddressInfo | null {

--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -65,13 +65,13 @@ export abstract class AbstractHDWallet {
         this._accounts.set(accountIndex, newNode);
     }
 
-    protected deriveAddress(
+    protected deriveAddressNode(
         account: number,
         startingIndex: number,
         zone: Zone,
         isChange: boolean = false,
     ): HDNodeWallet {
-        this.validateZone(zone);
+        // helper method to check if derived address is valid for a given zone
         const isValidAddressForZone = (address: string) => {
             const addressZone = getZoneForAddress(address);
             if (!addressZone) {
@@ -122,7 +122,7 @@ export abstract class AbstractHDWallet {
             }
         });
 
-        // derive the address node
+        // derive the address node and validate the zone
         const changeIndex = isChange ? 1 : 0;
         const addressNode = this._root.deriveChild(account).deriveChild(changeIndex).deriveChild(addressIndex);
         const zone = getZoneForAddress(addressNode.address);
@@ -130,19 +130,7 @@ export abstract class AbstractHDWallet {
             throw new Error(`Failed to derive a valid address zone for the index ${addressIndex}`);
         }
 
-        // create the NeuteredAddressInfo object and update the map
-        const neuteredAddressInfo = {
-            pubKey: addressNode.publicKey,
-            address: addressNode.address,
-            account: account,
-            index: addressNode.index,
-            change: isChange,
-            zone: zone,
-        };
-
-        addressMap.set(neuteredAddressInfo.address, neuteredAddressInfo);
-
-        return neuteredAddressInfo;
+        return this.createAndStoreAddressInfo(addressNode, account, zone, isChange, addressMap);
     }
 
     public getNextAddress(accountIndex: number, zone: Zone): NeuteredAddressInfo {
@@ -150,28 +138,10 @@ export abstract class AbstractHDWallet {
         if (!this._accounts.has(accountIndex)) {
             this.addAccount(accountIndex);
         }
+        const lastIndex = this.getLastAddressIndex(this._addresses, zone, accountIndex, false);
+        const addressNode = this.deriveAddressNode(accountIndex, lastIndex + 1, zone);
 
-        const filteredAccountInfos = Array.from(this._addresses.values()).filter(
-            (addressInfo) => addressInfo.account === accountIndex && addressInfo.zone === zone,
-        );
-        const lastIndex = filteredAccountInfos.reduce(
-            (maxIndex, addressInfo) => Math.max(maxIndex, addressInfo.index),
-            -1,
-        );
-        const addressNode = this.deriveAddress(accountIndex, lastIndex + 1, zone);
-
-        // create the NeuteredAddressInfo object and update the maps
-        const neuteredAddressInfo = {
-            pubKey: addressNode.publicKey,
-            address: addressNode.address,
-            account: accountIndex,
-            index: addressNode.index,
-            change: false,
-            zone: zone,
-        };
-        this._addresses.set(neuteredAddressInfo.address, neuteredAddressInfo);
-
-        return neuteredAddressInfo;
+        return this.createAndStoreAddressInfo(addressNode, accountIndex, zone, false, this._addresses);
     }
 
     public getAddressInfo(address: string): NeuteredAddressInfo | null {
@@ -370,5 +340,72 @@ export abstract class AbstractHDWallet {
                 throw new Error(`Zone mismatch: ${addressInfo.zone} != ${newAddressInfo.zone}`);
             }
         }
+    }
+
+    /**
+     * Retrieves the highest address index from the given address map for a specified zone, account, and change type.
+     *
+     * This method filters the address map based on the provided zone, account, and change type, then determines the
+     * maximum address index from the filtered addresses.
+     *
+     * @param {Map<string, NeuteredAddressInfo>} addressMap - The map containing address information, where the key is
+     *   an address string and the value is a NeuteredAddressInfo object.
+     * @param {Zone} zone - The specific zone to filter the addresses by.
+     * @param {number} account - The account number to filter the addresses by.
+     * @param {boolean} isChange - A boolean indicating whether to filter for change addresses (true) or receiving
+     *   addresses (false).
+     *
+     * @returns {number} - The highest address index for the specified criteria, or -1 if no addresses match.
+     * @protected
+     */
+    protected getLastAddressIndex(
+        addressMap: Map<string, NeuteredAddressInfo>,
+        zone: Zone,
+        account: number,
+        isChange: boolean,
+    ): number {
+        const addresses = Array.from(addressMap.values()).filter(
+            (addressInfo) =>
+                addressInfo.account === account && addressInfo.zone === zone && addressInfo.change === isChange,
+        );
+        return addresses.reduce((maxIndex, addressInfo) => Math.max(maxIndex, addressInfo.index), -1);
+    }
+
+    /**
+     * Creates and stores address information in the address map for a specified account, zone, and change type.
+     *
+     * This method constructs a NeuteredAddressInfo object using the provided HDNodeWallet and other parameters, then
+     * stores this information in the provided address map.
+     *
+     * @param {HDNodeWallet} addressNode - The HDNodeWallet object containing the address and public key information.
+     * @param {number} account - The account number to associate with the address.
+     * @param {Zone} zone - The specific zone to associate with the address.
+     * @param {boolean} isChange - A boolean indicating whether the address is a change address (true) or a receiving
+     *   address (false).
+     * @param {Map<string, NeuteredAddressInfo>} addressMap - The map to store the created NeuteredAddressInfo, with the
+     *   address as the key.
+     *
+     * @returns {NeuteredAddressInfo} - The created NeuteredAddressInfo object.
+     * @protected
+     */
+    protected createAndStoreAddressInfo(
+        addressNode: HDNodeWallet,
+        account: number,
+        zone: Zone,
+        isChange: boolean,
+        addressMap: Map<string, NeuteredAddressInfo>,
+    ): NeuteredAddressInfo {
+        const neuteredAddressInfo: NeuteredAddressInfo = {
+            pubKey: addressNode.publicKey,
+            address: addressNode.address,
+            account,
+            index: addressNode.index,
+            change: isChange,
+            zone,
+        };
+
+        addressMap.set(neuteredAddressInfo.address, neuteredAddressInfo);
+
+        return neuteredAddressInfo;
     }
 }

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -190,7 +190,7 @@ export class QiHDWallet extends AbstractHDWallet {
      * until the gap limit is reached for both gap and change addresses.
      *
      * @param {Zone} zone - The zone in which to scan for addresses.
-     * @param {number} [account=0] - The index of the account to scan. Defaults to 0. Default is `0`
+     * @param {number} [account=0] - The index of the account to scan. Defaults to 0. Default is `0` Default is `0`
      *
      * @returns {Promise<void>} A promise that resolves when the scan is complete.
      * @throws {Error} If the zone is invalid.
@@ -220,7 +220,23 @@ export class QiHDWallet extends AbstractHDWallet {
      */
     public async sync(zone: Zone, account?: number): Promise<void> {
         this.validateZone(zone);
-        return this._scan(zone, account);
+        // if no account is specified, scan all accounts.
+        if (account === undefined) {
+            const addressInfos = Array.from(this._addresses.values());
+            const accounts = addressInfos.reduce<number[]>((unique, info) => {
+                if (!unique.includes(info.account)) {
+                    unique.push(info.account);
+                }
+                return unique;
+            }, []);
+
+            for (const acc of accounts) {
+                await this._scan(zone, acc);
+            }
+        } else {
+            await this._scan(zone, account);
+        }
+        return;
     }
 
     /**
@@ -228,7 +244,7 @@ export class QiHDWallet extends AbstractHDWallet {
      * scanning logic, generating new addresses until the gap limit is reached for both gap and change addresses.
      *
      * @param {Zone} zone - The zone in which to scan for addresses.
-     * @param {number} [account=0] - The index of the account to scan. Defaults to 0. Default is `0`
+     * @param {number} [account=0] - The index of the account to scan. Defaults to 0. Default is `0` Default is `0`
      *
      * @returns {Promise<void>} A promise that resolves when the scan is complete.
      * @throws {Error} If the provider is not set.

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -280,7 +280,7 @@ export class QiHDWallet extends AbstractHDWallet {
             }
             return Object.values(outpointsMap) as Outpoint[];
         } catch (error) {
-            throw new Error(`Failed to get outpoints for address: ${address}`);
+            throw new Error(`Failed to get outpoints for address: ${address} - error: ${error}`);
         }
     }
 

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -52,7 +52,7 @@ export class QiHDWallet extends AbstractHDWallet {
     public getNextChangeAddress(account: number, zone: Zone): NeuteredAddressInfo {
         this.validateZone(zone);
         const lastIndex = this.getLastAddressIndex(this._changeAddresses, zone, account, true);
-        const addressNode = this.deriveAddressNode(account, lastIndex + 1, zone, true);
+        const addressNode = this.deriveNextAddressNode(account, lastIndex + 1, zone, true);
 
         return this.createAndStoreAddressInfo(addressNode, account, zone, true, this._changeAddresses);
     }

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -49,6 +49,14 @@ export class QiHDWallet extends AbstractHDWallet {
         super(root, provider);
     }
 
+    /**
+     * Retrieves the next change address for the specified account and zone.
+     *
+     * @param {number} account - The index of the account for which to retrieve the next change address.
+     * @param {Zone} zone - The zone in which to retrieve the next change address.
+     *
+     * @returns {NeuteredAddressInfo} The next change neutered address information.
+     */
     public getNextChangeAddress(account: number, zone: Zone): NeuteredAddressInfo {
         return this._getNextAddress(account, zone, true, this._changeAddresses);
     }
@@ -177,9 +185,16 @@ export class QiHDWallet extends AbstractHDWallet {
         return addressNode.privateKey;
     }
 
-    // scan scans the specified zone for addresses with unspent outputs.
-    // Starting at index 0, tt will generate new addresses until
-    // the gap limit is reached for both gap and change addresses.
+    /**
+     * Scans the specified zone for addresses with unspent outputs. Starting at index 0, it will generate new addresses
+     * until the gap limit is reached for both gap and change addresses.
+     *
+     * @param {Zone} zone - The zone in which to scan for addresses.
+     * @param {number} [account=0] - The index of the account to scan. Defaults to 0. Default is `0`
+     *
+     * @returns {Promise<void>} A promise that resolves when the scan is complete.
+     * @throws {Error} If the zone is invalid.
+     */
     public async scan(zone: Zone, account: number = 0): Promise<void> {
         this.validateZone(zone);
         // flush the existing addresses and outpoints
@@ -192,15 +207,32 @@ export class QiHDWallet extends AbstractHDWallet {
         await this._scan(zone, account);
     }
 
-    // sync scans the specified zone for addresses with unspent outputs.
-    // Starting at the last address index, it will generate new addresses until
-    // the gap limit is reached for both gap and change addresses.
-    // If no account is specified, it will scan all accounts known to the wallet
+    /**
+     * Scans the specified zone for addresses with unspent outputs. Starting at the last address index, it will generate
+     * new addresses until the gap limit is reached for both gap and change addresses. If no account is specified, it
+     * will scan all accounts known to the wallet.
+     *
+     * @param {Zone} zone - The zone in which to sync addresses.
+     * @param {number} [account] - The index of the account to sync. If not specified, all accounts will be scanned.
+     *
+     * @returns {Promise<void>} A promise that resolves when the sync is complete.
+     * @throws {Error} If the zone is invalid.
+     */
     public async sync(zone: Zone, account?: number): Promise<void> {
         this.validateZone(zone);
         return this._scan(zone, account);
     }
 
+    /**
+     * Internal method to scan the specified zone for addresses with unspent outputs. This method handles the actual
+     * scanning logic, generating new addresses until the gap limit is reached for both gap and change addresses.
+     *
+     * @param {Zone} zone - The zone in which to scan for addresses.
+     * @param {number} [account=0] - The index of the account to scan. Defaults to 0. Default is `0`
+     *
+     * @returns {Promise<void>} A promise that resolves when the scan is complete.
+     * @throws {Error} If the provider is not set.
+     */
     private async _scan(zone: Zone, account: number = 0): Promise<void> {
         if (!this.provider) throw new Error('Provider not set');
 
@@ -219,6 +251,18 @@ export class QiHDWallet extends AbstractHDWallet {
         }
     }
 
+    /**
+     * Scans for the next address in the specified zone and account, checking for associated outpoints, and updates the
+     * address count and gap addresses accordingly.
+     *
+     * @param {Zone} zone - The zone in which the address is being scanned.
+     * @param {number} account - The index of the account for which the address is being scanned.
+     * @param {boolean} isChange - A flag indicating whether the address is a change address.
+     * @param {number} addressesCount - The current count of addresses scanned.
+     *
+     * @returns {Promise<number>} A promise that resolves to the updated address count.
+     * @throws {Error} If an error occurs during the address scanning or outpoints retrieval process.
+     */
     private async scanAddress(zone: Zone, account: number, isChange: boolean, addressesCount: number): Promise<number> {
         const addressMap = isChange ? this._changeAddresses : this._addresses;
         const addressInfo = this._getNextAddress(account, zone, isChange, addressMap);

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -54,28 +54,10 @@ export class QiHDWallet extends AbstractHDWallet {
         if (!this._accounts.has(account)) {
             this.addAccount(account);
         }
-        const filteredAccountInfos = Array.from(this._changeAddresses.values()).filter(
-            (addressInfo) => addressInfo.account === account && addressInfo.zone === zone,
-        );
-        const lastIndex = filteredAccountInfos.reduce(
-            (maxIndex, addressInfo) => Math.max(maxIndex, addressInfo.index),
-            -1,
-        );
-        // call derive address with change = true
-        const addressNode = this.deriveAddress(account, lastIndex + 1, zone, true);
+        const lastIndex = this.getLastAddressIndex(this._changeAddresses, zone, account, true);
+        const addressNode = this.deriveAddressNode(account, lastIndex + 1, zone, true);
 
-        const neuteredAddressInfo = {
-            pubKey: addressNode.publicKey,
-            address: addressNode.address,
-            account: account,
-            index: addressNode.index,
-            change: true,
-            zone: zone,
-        };
-
-        this._changeAddresses.set(neuteredAddressInfo.address, neuteredAddressInfo);
-
-        return neuteredAddressInfo;
+        return this.createAndStoreAddressInfo(addressNode, account, zone, true, this._changeAddresses);
     }
 
     public importOutpoints(outpoints: OutpointInfo[]): void {

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -50,11 +50,7 @@ export class QiHDWallet extends AbstractHDWallet {
     }
 
     public getNextChangeAddress(account: number, zone: Zone): NeuteredAddressInfo {
-        this.validateZone(zone);
-        const lastIndex = this.getLastAddressIndex(this._changeAddresses, zone, account, true);
-        const addressNode = this.deriveNextAddressNode(account, lastIndex + 1, zone, true);
-
-        return this.createAndStoreAddressInfo(addressNode, account, zone, true, this._changeAddresses);
+        return this._getNextAddress(account, zone, true, this._changeAddresses);
     }
 
     public importOutpoints(outpoints: OutpointInfo[]): void {
@@ -211,50 +207,38 @@ export class QiHDWallet extends AbstractHDWallet {
         let gapAddressesCount = 0;
         let changeGapAddressesCount = 0;
 
-        // helper function to handle the common logic for both gap and change addresses
-        const handleAddressScanning = async (
-            getAddressInfo: () => NeuteredAddressInfo,
-            addressesCount: number,
-            gapAddressesArray: NeuteredAddressInfo[],
-        ): Promise<number> => {
-            const addressInfo = getAddressInfo();
-            const outpoints = await this.getOutpointsByAddress(addressInfo.address);
-            if (outpoints.length === 0) {
-                addressesCount++;
-                gapAddressesArray.push(addressInfo);
-            } else {
-                addressesCount = 0;
-                gapAddressesArray = [];
-                const newOutpointsInfo = outpoints.map((outpoint) => ({
-                    outpoint,
-                    address: addressInfo.address,
-                    zone: zone,
-                }));
-                this._outpoints.push(...newOutpointsInfo);
-            }
-            return addressesCount;
-        };
-
-        // main loop to scan addresses up to the gap limit
         while (gapAddressesCount < QiHDWallet._GAP_LIMIT || changeGapAddressesCount < QiHDWallet._GAP_LIMIT) {
             [gapAddressesCount, changeGapAddressesCount] = await Promise.all([
                 gapAddressesCount < QiHDWallet._GAP_LIMIT
-                    ? handleAddressScanning(
-                          () => this.getNextAddress(account, zone),
-                          gapAddressesCount,
-                          this._gapAddresses,
-                      )
+                    ? this.scanAddress(zone, account, false, gapAddressesCount)
                     : gapAddressesCount,
-
                 changeGapAddressesCount < QiHDWallet._GAP_LIMIT
-                    ? handleAddressScanning(
-                          () => this.getNextChangeAddress(account, zone),
-                          changeGapAddressesCount,
-                          this._gapChangeAddresses,
-                      )
+                    ? this.scanAddress(zone, account, true, changeGapAddressesCount)
                     : changeGapAddressesCount,
             ]);
         }
+    }
+
+    private async scanAddress(zone: Zone, account: number, isChange: boolean, addressesCount: number): Promise<number> {
+        const addressMap = isChange ? this._changeAddresses : this._addresses;
+        const addressInfo = this._getNextAddress(account, zone, isChange, addressMap);
+        const outpoints = await this.getOutpointsByAddress(addressInfo.address);
+        if (outpoints.length > 0) {
+            this.importOutpoints(
+                outpoints.map((outpoint) => ({
+                    outpoint,
+                    address: addressInfo.address,
+                    zone,
+                    account,
+                })),
+            );
+            addressesCount = 0;
+            isChange ? (this._gapChangeAddresses = []) : (this._gapAddresses = []);
+        } else {
+            addressesCount++;
+            isChange ? this._gapChangeAddresses.push(addressInfo) : this._gapAddresses.push(addressInfo);
+        }
+        return addressesCount;
     }
 
     // getOutpointsByAddress queries the network node for the outpoints of the specified address

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -51,9 +51,6 @@ export class QiHDWallet extends AbstractHDWallet {
 
     public getNextChangeAddress(account: number, zone: Zone): NeuteredAddressInfo {
         this.validateZone(zone);
-        if (!this._accounts.has(account)) {
-            this.addAccount(account);
-        }
         const lastIndex = this.getLastAddressIndex(this._changeAddresses, zone, account, true);
         const addressNode = this.deriveAddressNode(account, lastIndex + 1, zone, true);
 
@@ -176,12 +173,11 @@ export class QiHDWallet extends AbstractHDWallet {
         const addressInfo = this.getAddressInfo(address);
         if (!addressInfo) throw new Error(`Address not found: ${address}`);
         // derive an HDNode for the address and get the private key
-        const accountNode = this._accounts.get(addressInfo.account);
-        if (!accountNode) {
-            throw new Error(`Account ${addressInfo.account} not found for address ${address}`);
-        }
-        const changeNode = accountNode.deriveChild(0);
-        const addressNode = changeNode.deriveChild(addressInfo.index);
+        const changeIndex = addressInfo.change ? 1 : 0;
+        const addressNode = this._root
+            .deriveChild(addressInfo.account)
+            .deriveChild(changeIndex)
+            .deriveChild(addressInfo.index);
         return addressNode.privateKey;
     }
 
@@ -206,21 +202,11 @@ export class QiHDWallet extends AbstractHDWallet {
     // If no account is specified, it will scan all accounts known to the wallet
     public async sync(zone: Zone, account?: number): Promise<void> {
         this.validateZone(zone);
-        if (account) {
-            await this._scan(zone, account);
-        } else {
-            for (const account of this._accounts.keys()) {
-                await this._scan(zone, account);
-            }
-        }
+        return this._scan(zone, account);
     }
 
     private async _scan(zone: Zone, account: number = 0): Promise<void> {
         if (!this.provider) throw new Error('Provider not set');
-
-        if (!this._accounts.has(account)) {
-            this.addAccount(account);
-        }
 
         let gapAddressesCount = 0;
         let changeGapAddressesCount = 0;
@@ -399,13 +385,13 @@ export class QiHDWallet extends AbstractHDWallet {
         outpointInfo.forEach((info) => {
             // validate zone
             this.validateZone(info.zone);
-            // validate address
-            if (!this._addresses.has(info.address)) {
+            // validate address and account
+            const addressInfo = this.getAddressInfo(info.address);
+            if (!addressInfo) {
                 throw new Error(`Address ${info.address} not found in wallet`);
             }
-            // validate account
-            if (info.account && !this._accounts.has(info.account)) {
-                throw new Error(`Account ${info.account} not found in wallet`);
+            if (info.account !== undefined && info.account !== addressInfo.account) {
+                throw new Error(`Account ${info.account} not found for address ${info.address}`);
             }
             // validate Outpoint
             if (info.outpoint.txhash == null || info.outpoint.index == null || info.outpoint.denomination == null) {

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -124,7 +124,7 @@ export class QiHDWallet extends AbstractHDWallet {
 
     // createSchnorrSignature returns a schnorr signature for the given message and private key
     private createSchnorrSignature(input: TxInput, hash: Uint8Array): string {
-        const privKey = this.derivePrivateKeyForInput(input);
+        const privKey = this.getPrivateKeyForTxInput(input);
         const signature = schnorr.sign(hash, getBytes(privKey));
         return hexlify(signature);
     }
@@ -137,7 +137,7 @@ export class QiHDWallet extends AbstractHDWallet {
         // Collect private keys corresponding to the pubkeys found on the inputs
         const privKeysSet = new Set<string>();
         tx.txInputs!.forEach((input) => {
-            const privKey = this.derivePrivateKeyForInput(input);
+            const privKey = this.getPrivateKeyForTxInput(input);
             privKeysSet.add(privKey);
         });
         const privKeys = Array.from(privKeysSet);
@@ -169,8 +169,24 @@ export class QiHDWallet extends AbstractHDWallet {
         return hexlify(finalSignature);
     }
 
-    // Helper method that returns the private key for the public key
-    private derivePrivateKeyForInput(input: TxInput): string {
+    /**
+     * Retrieves the private key for a given transaction input.
+     *
+     * This method derives the private key for a transaction input by following these steps:
+     *
+     * 1. Ensures the input contains a public key.
+     * 2. Computes the address from the public key.
+     * 3. Fetches address information associated with the computed address.
+     * 4. Derives the hierarchical deterministic (HD) node corresponding to the address.
+     * 5. Returns the private key of the derived HD node.
+     *
+     * @private
+     * @param {TxInput} input - The transaction input containing the public key.
+     *
+     * @returns {string} The private key corresponding to the transaction input.
+     * @throws {Error} If the input does not contain a public key or if the address information cannot be found.
+     */
+    private getPrivateKeyForTxInput(input: TxInput): string {
         if (!input.pubkey) throw new Error('Missing public key for input');
         const address = computeAddress(input.pubkey);
         // get address info
@@ -191,6 +207,7 @@ export class QiHDWallet extends AbstractHDWallet {
      *
      * @param {Zone} zone - The zone in which to scan for addresses.
      * @param {number} [account=0] - The index of the account to scan. Defaults to 0. Default is `0` Default is `0`
+     *   Default is `0`
      *
      * @returns {Promise<void>} A promise that resolves when the scan is complete.
      * @throws {Error} If the zone is invalid.
@@ -245,6 +262,7 @@ export class QiHDWallet extends AbstractHDWallet {
      *
      * @param {Zone} zone - The zone in which to scan for addresses.
      * @param {number} [account=0] - The index of the account to scan. Defaults to 0. Default is `0` Default is `0`
+     *   Default is `0`
      *
      * @returns {Promise<void>} A promise that resolves when the scan is complete.
      * @throws {Error} If the provider is not set.


### PR DESCRIPTION
Changes in this PR:
1. Removes duplicated logic in Quai and Qi HD Wallet
2. Fixes a bug in `getOutpointsByAddress()` method in `abstract-provider.ts`
3. Removes the `_accounts` map from `AbstractHDWallet`
4. Adds JSDOC comments to several methods
5. Simplies logic in some wallet methods