### PR TITLE
Add frontmatter icons

### DIFF
--- a/docs/plugins/typedoc-plugin-mintlify-frontmatter.mjs
+++ b/docs/plugins/typedoc-plugin-mintlify-frontmatter.mjs
@@ -13,8 +13,12 @@ export function load(app) {
          * @param {import('typedoc-plugin-markdown').MarkdownPageEvent} page
          */
         (page) => {
+            const iconLetter = page.url.charAt(0);
+            const icon = 'square-' + iconLetter;
             page.frontmatter = {
                 title: page.model?.name,
+                icon: icon,
+                iconType: "solid",
                 ...page.frontmatter,
             };
         },

--- a/docs/static/abi.mdx
+++ b/docs/static/abi.mdx
@@ -1,6 +1,8 @@
 ---
 title: Application Binary Interfaces
+sidebarTitle: abi
 description: 'Implement smart contracts through their Application Binary Interface (ABI).'
+icon: 'bars'
 ---
 
 When interacting with any application, whether it is on Quai Network, over the internet or within a compiled application on a computer all information is stored and sent as binary data which is just a sequence of bytes.
@@ -50,3 +52,49 @@ For example, the event `Transfer(address indexed from, address indexed to, uint 
 When deploying a transaction, the data provided is treated as **initcode**, which executes the data as normal EVM bytecode, which returns a sequence of bytes, but instead of that sequence of bytes being treated as data that result is instead the bytecode to install as the bytecode of the contract.
 
 The bytecode produced by Solidity is designed to have all constructor parameters encoded normally and concatenated to the bytecode and provided as the `data` to a transaction with no `to` address.
+
+## Classes
+
+|                                                                   |                                                                    |
+| :---------------------------------------------------------------- | :----------------------------------------------------------------- |
+| [ConstructorFragment](/content/classes/ConstructorFragment)       | A fragment of a contract ABI that represents a constructor.        |
+| [ErrorDescription](/content/classes/ErrorDescription)             | A description of an error in a contract ABI.                       |
+| [ErrorFragment](/content/classes/ErrorFragment)                   | A fragment of a contract ABI that represents an error.             |
+| [EventFragment](/content/classes/EventFragment)                   | A fragment of a contract ABI that represents an event.             |
+| [FallbackFragment](/content/classes/FallbackFragment)             | A fragment of a contract ABI that represents a fallback function.  |
+| [Fragment](/content/classes/Fragment)                             | A fragment of a contract ABI.                                      |
+| [FunctionFragment](/content/classes/FunctionFragment)             | A fragment of a contract ABI that represents a function.           |
+| [Indexed](/content/classes/Indexed)                               | A fragment of a contract ABI that represents an indexed parameter. |
+| [Interface](/content/classes/Interface)                           | An interface ABI.                                                  |
+| [LogDescription](/content/classes/LogDescription)                 | A description of a log in a contract ABI.                          |
+| [NamedFragment](/content/classes/NamedFragment)                   | A fragment of a contract ABI that has a name.                      |
+| [ParamType](/content/classes/ParamType)                           | A fragment of a contract ABI that represents a parameter type.     |
+| [Result](/content/classes/Result)                                 | A fragment of a contract ABI that represents a result.             |
+| [StructFragment](/content/classes/StructFragment)                 | A fragment of a contract ABI that represents a struct.             |
+| [TransactionDescription](/content/classes/TransactionDescription) | A description of a transaction in a contract ABI.                  |
+| [Typed](/content/classes/Typed)                                   | A fragment of a contract ABI that represents a typed parameter.    |
+
+## Interfaces
+
+|                                                          |                                                        |
+| :------------------------------------------------------- | :----------------------------------------------------- |
+| [JsonFragment](/content/interfaces/JsonFragment)         | A JSON representation of a contract ABI fragment.      |
+| [JsonFragmentType](/content/interfaces/JsonFragmentType) | A JSON representation of a contract ABI fragment type. |
+
+## Types
+
+|                                                                        |                                                                    |
+| :--------------------------------------------------------------------- | :----------------------------------------------------------------- |
+| [FormatType](/content/type-aliases/FormatType)                         | A type that represents a format.                                   |
+| [FragmentType](/content/type-aliases/FragmentType)                     | A type that represents a fragment.                                 |
+| [InterfaceAbi](/content/type-aliases/InterfaceAbi)                     | A type that represents an interface ABI.                           |
+| [ParamTypeWalkAsyncFunc](/content/type-aliases/ParamTypeWalkAsyncFunc) | A type that represents an async function to walk a parameter type. |
+| [ParamTypeWalkFunc](/content/type-aliases/ParamTypeWalkFunc)           | A type that represents a function to walk a parameter type.        |
+
+## Functions
+
+|                                                               |                                    |
+| :------------------------------------------------------------ | :--------------------------------- |
+| [checkResultErrors](/content/functions/checkResultErrors)     | Check if a result contains errors. |
+| [decodeBytes32String](/content/functions/decodeBytes32String) | Decode a bytes32 string.           |
+| [encodeBytes32String](/content/functions/encodeBytes32String) | Encode a string as bytes32.        |

--- a/docs/static/address.mdx
+++ b/docs/static/address.mdx
@@ -1,13 +1,40 @@
 ---
 title: Addresses
+sidebarTitle: address
 description: ''
+icon: 'user-secret'
 ---
 
-Addresses are a fundamental part of interacting with Quai Network. They represent the gloabal identity of Externally Owned Accounts (accounts backed by a private key), contracts, and UTXO wallets.
+**Addresses are a fundamental part of interacting with Quai Network**. They represent the global identity of Externally Owned Accounts (accounts backed by a private key), contracts, and UTXO wallets.
 
 These functions help convert between various formats, validate addresses across the Quai and Qi address spaces, and other utilities for working with addresses.
 
 The Quais SDK supports the following address formats:
 
--   `quai` addresses
--   `qi` addresses
+- `quai` addresses
+- `qi` addresses
+
+## Interfaces
+
+|                                                |                                                |
+| :--------------------------------------------- | :--------------------------------------------- |
+| [Addressable](/content/interfaces/Addressable) | An interface for objects that have an address. |
+
+## Types
+
+|                                                  |                                    |
+| :----------------------------------------------- | :--------------------------------- |
+| [AddressLike](/content/type-aliases/AddressLike) | A type that represents an address. |
+
+## Functions
+
+|                                                           |                                                                                             |
+| :-------------------------------------------------------- | :------------------------------------------------------------------------------------------ |
+| [computeAddress](/content/functions/computeAddress)       | Compute the address of a contract created by a given address and nonce.                     |
+| [getAddress](/content/functions/getAddress)               | Get the address of a contract created by a given address and nonce.                         |
+| [getCreateAddress](/content/functions/getCreateAddress)   | Get the address of a contract created by a given address and nonce.                         |
+| [getCreate2Address](/content/functions/getCreate2Address) | Get the address of a contract created by a given address and salt using the CREATE2 opcode. |
+| [isAddress](/content/functions/isAddress)                 | Check if a string is a valid address.                                                       |
+| [isAddressable](/content/functions/isAddressable)         | Check if an object is an addressable object.                                                |
+| [recoverAddress](/content/functions/recoverAddress)       | Recover the address of a signer from a signature.                                           |
+| [resolveAddress](/content/functions/resolveAddress)       | Resolve an address from a value.                                                            |

--- a/docs/static/constants.mdx
+++ b/docs/static/constants.mdx
@@ -1,4 +1,21 @@
 ---
 title: Constants
+sidebarTitle: constants
 description: 'A collection of useful constants when interacting with Quai Network.'
+icon: 'cube'
 ---
+
+Some common constants useful for interacting with Quai and Qi.
+
+## Variables
+
+|                                                   |                                                       |
+| ------------------------------------------------- | ----------------------------------------------------- |
+| [MaxInt256](/content/variables/MaxInt256)         | The maximum value of a signed 256-bit integer.        |
+| [MaxUint256](/content/variables/MaxUint256)       | The maximum value of an unsigned 256-bit integer.     |
+| [MessagePrefix](/content/variables/MessagePrefix) | The prefix used when signing messages.                |
+| [MinInt256](/content/variables/MinInt256)         | The minimum value of a signed 256-bit integer.        |
+| [N](/content/variables/N)                         | The order of the elliptic curve used in Quai Network. |
+| [WeiPerEther](/content/variables/WeiPerEther)     | The number of wei in one ether.                       |
+| [ZeroAddress](/content/variables/ZeroAddress)     | The address that represents zero.                     |
+| [ZeroHash](/content/variables/ZeroHash)           | The hash that represents zero.                        |

--- a/docs/static/contract.mdx
+++ b/docs/static/contract.mdx
@@ -1,0 +1,44 @@
+---
+title: Contracts
+sidebarTitle: Smart Contracts
+description: 'Contract connection and interaction utilities.'
+icon: 'file-code'
+---
+
+A Contract object is a meta-class, which **communicates with a deployed smart contract** on the blockchain and provides a simple JavaScript interface to call methods, send transaction, and query historic logs.
+
+## Classes
+
+|                                                                             |                                                                                     |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [BaseContract](/content/classes/BaseContract)                               | Base class for all contract types.                                                  |
+| [Contract](/content/classes/Contract)                                       | A contract class that can be connected to an address and allows for calling methods |
+| [ContractEventPayload](/content/classes/ContractEventPayload)               | A contract event payload.                                                           |
+| [ContractFactory](/content/classes/ContractFactory)                         | A factory for deploying contracts.                                                  |
+| [ContractTransactionReceipt](/content/classes/ContractTransactionReceipt)   | A contract transaction receipt.                                                     |
+| [ContractTransactionResponse](/content/classes/ContractTransactionResponse) | A contract transaction response.                                                    |
+| [ContractUnknownEventPayload](/content/classes/ContractUnknownEventPayload) | A contract unknown event payload.                                                   |
+| [EventLog](/content/classes/EventLog)                                       | An event log.                                                                       |
+| [UndecodedEventLog](/content/classes/UndecodedEventLog)                     | An undecoded event log.                                                             |
+
+## Interfaces
+
+|                                                                            |                                  |
+| -------------------------------------------------------------------------- | -------------------------------- |
+| [BaseContractMethod](/content/interfaces/BaseContractMethod)               | A base contract method.          |
+| [ConstantContractMethod](/content/interfaces/ConstantContractMethod)       | A constant contract method.      |
+| [ContractDeployTransaction](/content/interfaces/ContractDeployTransaction) | A contract deploy transaction.   |
+| [ContractEvent](/content/interfaces/ContractEvent)                         | A contract event.                |
+| [ContractInterface](/content/interfaces/ContractInterface)                 | A contract interface.            |
+| [ContractMethod](/content/interfaces/ContractMethod)                       | A contract method.               |
+| [ContractRunner](/content/interfaces/ContractRunner)                       | A contract runner.               |
+| [ContractTransaction](/content/interfaces/ContractTransaction)             | A contract transaction.          |
+| [DeferredTopicFilter](/content/interfaces/DeferredTopicFilter)             | A deferred topic filter.         |
+| [Overrides](/content/interfaces/Overrides)                                 | Overrides for a contract method. |
+| [WrappedFallback](/content/interfaces/WrappedFallback)                     | A wrapped fallback function.     |
+
+## Types
+
+|                                                              |                                               |
+| ------------------------------------------------------------ | --------------------------------------------- |
+| [ContractEventName](/content/type-aliases/ContractEventName) | A type that represents a contract event name. |

--- a/docs/static/crypto.mdx
+++ b/docs/static/crypto.mdx
@@ -1,6 +1,37 @@
 ---
 title: Cryptographic Functions
+sidebarTitle: crypto
 description: 'A set of common cryptographic functions used in Quai Network.'
+icon: 'brackets-curly'
 ---
 
-A fundamental building block of Quai Network is the underlying cryptographic primitives.
+A fundamental building block of Quai Network is the underlying **cryptographic primitives**.
+
+## Classes
+
+|                                           |                              |
+| ----------------------------------------- | ---------------------------- |
+| [Signature](/content/classes/Signature)   | A cryptographic signature.   |
+| [SigningKey](/content/classes/SigningKey) | A cryptographic signing key. |
+
+## Types
+
+|                                                            |                                                          |
+| ---------------------------------------------------------- | -------------------------------------------------------- |
+| [ProgressCallback](/content/type-aliases/ProgressCallback) | A callback function that can be used to report progress. |
+| [SignatureLike](/content/type-aliases/SignatureLike)       | A signature-like object.                                 |
+
+## Functions
+
+|                                               |                                                   |
+| --------------------------------------------- | ------------------------------------------------- |
+| [computeHmac](/content/functions/computeHmac) | Compute an HMAC.                                  |
+| [keccak256](/content/functions/keccak256)     | Compute the Keccak-256 hash of a value.           |
+| [lock](/content/functions/lock)               | Lock a function to prevent reentrancy.            |
+| [pbkdf2](/content/functions/pbkdf2)           | Compute a PBKDF2 hash.                            |
+| [randomBytes](/content/functions/randomBytes) | Generate random bytes.                            |
+| [ripemd160](/content/functions/ripemd160)     | Compute the RIPEMD-160 hash of a value.           |
+| [scrypt](/content/functions/scrypt)           | Compute the scrypt hash of a value.               |
+| [scryptSync](/content/functions/scryptSync)   | Compute the scrypt hash of a value synchronously. |
+| [sha256](/content/functions/sha256)           | Compute the SHA-256 hash of a value.              |
+| [sha512](/content/functions/sha512)           | Compute the SHA-512 hash of a value.              |

--- a/docs/static/encoding.mdx
+++ b/docs/static/encoding.mdx
@@ -1,4 +1,38 @@
 ---
 title: Encoding Utilities
+sidebarTitle: encoding
 description: 'Utilities for common tasks involving data encoding.'
+icon: 'laptop-binary'
 ---
+
+A collection of useful encoding functions, many of which used when handling of `WorkObjects` and **Protobuf encoded data**.
+
+## Types
+
+|                                                                            |                                                     |
+| -------------------------------------------------------------------------- | --------------------------------------------------- |
+| [UnicodeNormalizationForm](/content/type-aliases/UnicodeNormalizationForm) | A Unicode normalization form.                       |
+| [Utf8ErrorFunc](/content/type-aliases/Utf8ErrorFunc)                       | A function that can be used to handle UTF-8 errors. |
+| [Utf8ErrorReason](/content/type-aliases/Utf8ErrorReason)                   | A reason for a UTF-8 error.                         |
+
+## Variables
+
+|                                                     |                                                 |
+| --------------------------------------------------- | ----------------------------------------------- |
+| [Utf8ErrorFuncs](/content/variables/Utf8ErrorFuncs) | A set of common UTF-8 error handling functions. |
+
+## Functions
+
+|                                                                     |                                        |
+| ------------------------------------------------------------------- | -------------------------------------- |
+| [decodeBase58](/content/functions/decodeBase58)                     | Decode a Base58-encoded string.        |
+| [decodeBase64](/content/functions/decodeBase64)                     | Decode a Base64-encoded string.        |
+| [decodeProtoTransaction](/content/functions/decodeProtoTransaction) | Decode a protobuf-encoded transaction. |
+| [decodeProtoWorkObject](/content/functions/decodeProtoWorkObject)   | Decode a protobuf-encoded work object. |
+| [encodeBase58](/content/functions/encodeBase58)                     | Encode a string as Base58.             |
+| [encodeBase64](/content/functions/encodeBase64)                     | Encode a string as Base64.             |
+| [encodeProtoTransaction](/content/functions/encodeProtoTransaction) | Encode a transaction as a protobuf.    |
+| [encodeProtoWorkObject](/content/functions/encodeProtoWorkObject)   | Encode a work object as a protobuf.    |
+| [toUtf8Bytes](/content/functions/toUtf8Bytes)                       | Convert a string to UTF-8 bytes.       |
+| [toUtf8CodePoints](/content/functions/toUtf8CodePoints)             | Convert a string to UTF-8 code points. |
+| [toUtf8String](/content/functions/toUtf8String)                     | Convert a string to UTF-8.             |

--- a/docs/static/hash.mdx
+++ b/docs/static/hash.mdx
@@ -1,4 +1,33 @@
 ---
 title: Hashing Utilities
+sidebarTitle: hash
 description: 'Utilities for common tasks involving hashing.'
+icon: 'binary-lock'
 ---
+
+A collection of useful hashing functions, generally used for *typed data*, *message verification*, and *Solidity operations*.
+
+## Classes
+
+|                                                       |                                          |
+| ----------------------------------------------------- | ---------------------------------------- |
+| [TypedDataEncoder](/content/classes/TypedDataEncoder) | A utility class for encoding typed data. |
+
+## Interfaces
+
+|                                                        |                                     |
+| ------------------------------------------------------ | ----------------------------------- |
+| [TypedDataDomain](/content/interfaces/TypedDataDomain) | A domain definition for typed data. |
+| [TypedDataField](/content/interfaces/TypedDataField)   | A field definition for typed data.  |
+
+## Functions
+
+|                                                                       |                                                                                     |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [hashMessage](/content/functions/hashMessage)                         | Hash a message using the specified algorithm.                                       |
+| [id](/content/functions/id)                                           | Compute the ID of a typed data domain.                                              |
+| [solidityPacked](/content/functions/solidityPacked)                   | Compute the solidity-packed data of a typed data domain.                            |
+| [solidityPackedKeccak256](/content/functions/solidityPackedKeccak256) | Compute the solidity-packed data of a typed data domain and hash it with Keccak256. |
+| [solidityPackedSha256](/content/functions/solidityPackedSha256)       | Compute the solidity-packed data of a typed data domain and hash it with SHA256.    |
+| [verifyMessage](/content/functions/verifyMessage)                     | Verify a message signature.                                                         |
+| [verifyTypedData](/content/functions/verifyTypedData)                 | Verify a typed data signature.                                                      |

--- a/docs/static/provider.mdx
+++ b/docs/static/provider.mdx
@@ -1,8 +1,80 @@
 ---
 title: Providers
+sidebarTitle: Network Providers
 description: 'Configure and utilize a Provider to interact with Quai Network.'
+icon: 'circle-nodes'
 ---
 
-A Provider provides a connection to the blockchain, whch can be used to query its current state, simulate execution and send transactions to update the state.
+**A Provider establishes a connection to the blockchain**, whch can be used to query its current state, simulate execution and send transactions to update the state.
 
-It is one of the most fundamental components of interacting with a blockchain application, and there are many ways to connect, such as over HTTP, WebSockets or injected providers such as Pelagus.
+Providers are one of the most fundamental components of interacting with a blockchain application, and there are many ways to connect, such as *over HTTP*, *WebSockets* or *injected providers such as Pelagus*.
+
+## Classes
+
+|                                                                     |                                                                       |
+| ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [AbstractProvider](/content/classes/AbstractProvider)               | The base class for all providers.                                     |
+| [Block](/content/classes/Block)                                     | Represents a block on the blockchain.                                 |
+| [BrowserProvider](/content/classes/BrowserProvider)                 | A provider that uses the browser's built-in provider.                 |
+| [FeeData](/content/classes/FeeData)                                 | Represents the fee data for a transaction.                            |
+| [JsonRpcApiProvider](/content/classes/JsonRpcApiProvider)           | A provider that uses a JSON-RPC API.                                  |
+| [JsonRpcProvider](/content/classes/JsonRpcProvider)                 | A provider that uses a JSON-RPC API.                                  |
+| [Log](/content/classes/Log)                                         | Represents a log entry on the blockchain.                             |
+| [Network](/content/classes/Network)                                 | Represents a network on the blockchain.                               |
+| [SocketBlockSubscriber](/content/classes/SocketBlockSubscriber)     | A subscriber that listens for new blocks.                             |
+| [SocketEventSubscriber](/content/classes/SocketEventSubscriber)     | A subscriber that listens for new events.                             |
+| [SocketPendingSubscriber](/content/classes/SocketPendingSubscriber) | A subscriber that listens for pending transactions.                   |
+| [SocketProvider](/content/classes/SocketProvider)                   | A provider that uses a WebSocket connection.                          |
+| [SocketSubscriber](/content/classes/SocketSubscriber)               | A base class for all socket subscribers.                              |
+| [TransactionReceipt](/content/classes/TransactionReceipt)           | Represents the receipt of a transaction.                              |
+| [UnmanagedSubscriber](/content/classes/UnmanagedSubscriber)         | A subscriber that listens for events without managing the connection. |
+| [WebSocketProvider](/content/classes/WebSocketProvider)             | A provider that uses a WebSocket connection.                          |
+
+## Interfaces
+
+|                                                                          |                                               |
+| ------------------------------------------------------------------------ | --------------------------------------------- |
+| [AbstractProviderPlugin](/content/interfaces/AbstractProviderPlugin)     | An abstract provider plugin.                  |
+| [BlockParams](/content/interfaces/BlockParams)                           | Parameters for querying blocks.               |
+| [Eip1193Provider](/content/interfaces/Eip1193Provider)                   | An EIP-1193 provider.                         |
+| [EventFilter](/content/interfaces/EventFilter)                           | A filter for events.                          |
+| [Filter](/content/interfaces/Filter)                                     | A filter for logs.                            |
+| [FilterByBlockHash](/content/interfaces/FilterByBlockHash)               | A filter for logs by block hash.              |
+| [LogParams](/content/interfaces/LogParams)                               | Parameters for querying logs.                 |
+| [MinedBlock](/content/interfaces/MinedBlock)                             | A mined block.                                |
+| [Provider](/content/interfaces/Provider)                                 | A provider for the blockchain.                |
+| [Subscriber](/content/interfaces/Subscriber)                             | A subscriber for the blockchain.              |
+| [TransactionReceiptParams](/content/interfaces/TransactionReceiptParams) | Parameters for querying transaction receipts. |
+| [WebSocketLike](/content/interfaces/WebSocketLike)                       | A WebSocket-like interface.                   |
+
+## Types
+
+|                                                                                |                                         |
+| ------------------------------------------------------------------------------ | --------------------------------------- |
+| [AbstractProviderOptions](/content/type-aliases/AbstractProviderOptions)       | Options for an abstract provider.       |
+| [BlockTag](/content/type-aliases/BlockTag)                                     | A block tag.                            |
+| [DebugEventBrowserProvider](/content/type-aliases/DebugEventBrowserProvider)   | A debug event browser provider.         |
+| [JsonRpcApiProviderOptions](/content/type-aliases/JsonRpcApiProviderOptions)   | Options for a JSON-RPC API provider.    |
+| [JsonRpcError](/content/type-aliases/JsonRpcError)                             | An error from a JSON-RPC API.           |
+| [JsonRpcPayload](/content/type-aliases/JsonRpcPayload)                         | A JSON-RPC payload.                     |
+| [JsonRpcResult](/content/type-aliases/JsonRpcResult)                           | A JSON-RPC result.                      |
+| [MinedTransactionResponse](/content/type-aliases/MinedTransactionResponse)     | A mined transaction response.           |
+| [Networkish](/content/type-aliases/Networkish)                                 | A networkish type.                      |
+| [OrphanFilter](/content/type-aliases/OrphanFilter)                             | An orphan filter.                       |
+| [PerformActionFilter](/content/type-aliases/PerformActionFilter)               | A filter for performing an action.      |
+| [PerformActionRequest](/content/type-aliases/PerformActionRequest)             | A request for performing an action.     |
+| [PerformActionTransaction](/content/type-aliases/PerformActionTransaction)     | A transaction for performing an action. |
+| [PreparedTransactionRequest](/content/type-aliases/PreparedTransactionRequest) | A request for a prepared transaction.   |
+| [ProviderEvent](/content/type-aliases/ProviderEvent)                           | A provider event.                       |
+| [Subscription](/content/type-aliases/Subscription)                             | A subscription.                         |
+| [TopicFilter](/content/type-aliases/TopicFilter)                               | A filter for topics.                    |
+| [TransactionRequest](/content/type-aliases/TransactionRequest)                 | A transaction request.                  |
+| [TransactionResponse](/content/type-aliases/TransactionResponse)               | A transaction response.                 |
+| [TransactionResponseParams](/content/type-aliases/TransactionResponseParams)   | Parameters for a transaction response.  |
+| [WebSocketCreator](/content/type-aliases/WebSocketCreator)                     | A WebSocket creator.                    |
+
+## Functions
+
+|                                               |                 |
+| --------------------------------------------- | --------------- |
+| [copyRequest](/content/functions/copyRequest) | Copy a request. |

--- a/docs/static/signer.mdx
+++ b/docs/static/signer.mdx
@@ -1,6 +1,21 @@
 ---
 title: Signers
+sidebarTitle: Signers
 description: 'Configure and manage signers for Quai and Qi.'
+icon: 'key-skeleton-left-right'
 ---
 
 A Signer can represent an account on the either the Quai or Qi ledger, and is most often backed by a private key represented by a mnemonic or residing on a Hardware Wallet.
+
+## Classes
+
+|                                                   |                                           |
+| ------------------------------------------------- | ----------------------------------------- |
+| [AbstractSigner](/content/classes/AbstractSigner) | An abstract signer class.                 |
+| [VoidSigner](/content/classes/VoidSigner)         | A signer that does not sign transactions. |
+
+## Interfaces
+
+|                                      |                                                      |
+| ------------------------------------ | ---------------------------------------------------- |
+| [Signer](/content/interfaces/Signer) | An interface for objects that can sign transactions. |

--- a/docs/static/transactions.mdx
+++ b/docs/static/transactions.mdx
@@ -1,6 +1,38 @@
 ---
 title: Transactions
+sidebarTitle: Transactions
 description: 'Build and sign transactions on Quai Network.'
+icon: 'split'
 ---
 
-Transactions are a fundamental piece of Quai Network. Every state-changing operation within the network requires a signed transaction.
+Transactions are a fundamental piece of Quai Network. **Every state-changing operation within the network requires a signed transaction**.
+
+The Quais SDK supports both **Qi and Quai transactions**, and provides utilities for building and signing transactions.
+
+## Classes
+
+|                                                             |                                                |
+| ----------------------------------------------------------- | ---------------------------------------------- |
+| [AbstractTransaction](/content/classes/AbstractTransaction) | An abstract transaction class.                 |
+| [FewestCoinSelector](/content/classes/FewestCoinSelector)   | A coin selector that selects the fewest coins. |
+| [QiTransaction](/content/classes/QiTransaction)             | A transaction on the Qi network.               |
+
+## Interfaces
+
+|                                                        |                                                       |
+| ------------------------------------------------------ | ----------------------------------------------------- |
+| [TransactionLike](/content/interfaces/TransactionLike) | An interface for objects that represent transactions. |
+
+## Types
+
+|                                                          |                                                       |
+| -------------------------------------------------------- | ----------------------------------------------------- |
+| [AccessList](/content/type-aliases/AccessList)           | A type that represents an access list.                |
+| [AccessListEntry](/content/type-aliases/AccessListEntry) | A type that represents an access list entry.          |
+| [AccessListish](/content/type-aliases/AccessListish)     | A type that represents an access list or access list. |
+
+## Functions
+
+|                                                   |                                                             |
+| ------------------------------------------------- | ----------------------------------------------------------- |
+| [accessListify](/content/functions/accessListify) | Convert an access list or access listish to an access list. |

--- a/docs/static/utils.mdx
+++ b/docs/static/utils.mdx
@@ -1,6 +1,111 @@
 ---
 title: Utilities
+sidebarTitle: utils
 description: 'Utility functions for common tasks.'
+icon: 'wrench-simple'
 ---
 
 A collection of useful utilities for manipulating data, mathematical operations, and more.
+
+A large number of the available utilities are generally for *internal use and are not intended to be used directly by developers*. However, there are a number of utilities that are useful for developers, such as the `FixedNumber` class, which provides fixed-point arithmetic, and the `EventPayload` class, which provides a way to encode event payloads.
+
+## Classes
+
+|                                                 |                                               |
+| ----------------------------------------------- | --------------------------------------------- |
+| [EventPayload](/content/classes/EventPayload)   | A utility class for encoding event payloads.  |
+| [FetchRequest](/content/classes/FetchRequest)   | A utility class for making fetch requests.    |
+| [FetchResponse](/content/classes/FetchResponse) | A utility class for handling fetch responses. |
+| [FixedNumber](/content/classes/FixedNumber)     | A utility class for fixed-point numbers.      |
+
+## Interfaces
+
+|                                                                                |                                                         |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------- |
+| [ActionRejectedError](/content/interfaces/ActionRejectedError)                 | An error that occurs when an action is rejected.        |
+| [BadDataError](/content/interfaces/BadDataError)                               | An error that occurs when data is bad.                  |
+| [BufferOverrunError](/content/interfaces/BufferOverrunError)                   | An error that occurs when a buffer is overrun.          |
+| [CallExceptionError](/content/interfaces/CallExceptionError)                   | An error that occurs when a call exception is thrown.   |
+| [CancelledError](/content/interfaces/CancelledError)                           | An error that occurs when an operation is cancelled.    |
+| [EventEmitterable](/content/interfaces/EventEmitterable)                       | An interface for objects that can emit events.          |
+| [InsufficientFundsError](/content/interfaces/InsufficientFundsError)           | An error that occurs when there are insufficient funds. |
+| [InvalidArgumentError](/content/interfaces/InvalidArgumentError)               | An error that occurs when an argument is invalid.       |
+| [MissingArgumentError](/content/interfaces/MissingArgumentError)               | An error that occurs when an argument is missing.       |
+| [NetworkError](/content/interfaces/NetworkError)                               | An error that occurs when a network error occurs.       |
+| [NonceExpiredError](/content/interfaces/NonceExpiredError)                     | An error that occurs when a nonce is expired.           |
+| [NotImplementedError](/content/interfaces/NotImplementedError)                 | An error that occurs when a method is not implemented.  |
+| [NumericFaultError](/content/interfaces/NumericFaultError)                     | An error that occurs when a numeric fault occurs.       |
+| [ReplacementUnderpricedError](/content/interfaces/ReplacementUnderpricedError) | An error that occurs when a replacement is underpriced. |
+| [ServerError](/content/interfaces/ServerError)                                 | An error that occurs when a server error occurs.        |
+| [TimeoutError](/content/interfaces/TimeoutError)                               | An error that occurs when a timeout occurs.             |
+| [TransactionReplacedError](/content/interfaces/TransactionReplacedError)       | An error that occurs when a transaction is replaced.    |
+| [UnexpectedArgumentError](/content/interfaces/UnexpectedArgumentError)         | An error that occurs when an argument is unexpected.    |
+| [UnknownError](/content/interfaces/UnknownError)                               | An error that occurs when an unknown error occurs.      |
+| [UnsupportedOperationError](/content/interfaces/UnsupportedOperationError)     | An error that occurs when an operation is unsupported.  |
+| [quaisError](/content/interfaces/quaisError)                                   | An interface for quais errors.                          |
+
+## Types
+
+|                                                                            |                                                      |
+| -------------------------------------------------------------------------- | ---------------------------------------------------- |
+| [BigNumberish](/content/type-aliases/BigNumberish)                         | A type that represents a big number.                 |
+| [BytesLike](/content/type-aliases/BytesLike)                               | A type that represents bytes.                        |
+| [CallExceptionAction](/content/type-aliases/CallExceptionAction)           | A type that represents a call exception action.      |
+| [CallExceptionTransaction](/content/type-aliases/CallExceptionTransaction) | A type that represents a call exception transaction. |
+| [CodedquaisError](/content/type-aliases/CodedquaisError)                   | A type that represents a coded quais error.          |
+| [ErrorCode](/content/type-aliases/ErrorCode)                               | A type that represents an error code.                |
+| [FetchGatewayFunc](/content/type-aliases/FetchGatewayFunc)                 | A type that represents a fetch gateway function.     |
+| [FetchGetUrlFunc](/content/type-aliases/FetchGetUrlFunc)                   | A type that represents a fetch get URL function.     |
+| [FetchPreflightFunc](/content/type-aliases/FetchPreflightFunc)             | A type that represents a fetch preflight function.   |
+| [FetchProcessFunc](/content/type-aliases/FetchProcessFunc)                 | A type that represents a fetch process function.     |
+| [FetchRetryFunc](/content/type-aliases/FetchRetryFunc)                     | A type that represents a fetch retry function.       |
+| [FixedFormat](/content/type-aliases/FixedFormat)                           | A type that represents a fixed format.               |
+| [GetUrlResponse](/content/type-aliases/GetUrlResponse)                     | A type that represents a get URL response.           |
+| [Listener](/content/type-aliases/Listener)                                 | A type that represents a listener.                   |
+| [Numeric](/content/type-aliases/Numeric)                                   | A type that represents a numeric value.              |
+
+## Functions
+
+|                                                             |                                                    |
+| ----------------------------------------------------------- | -------------------------------------------------- |
+| [assert](/content/functions/assert)                         | Asserts that a condition is true.                  |
+| [assertArgument](/content/functions/assertArgument)         | Asserts that an argument is valid.                 |
+| [assertNormalize](/content/functions/assertNormalize)       | Asserts that a value is normalized.                |
+| [assertPrivate](/content/functions/assertPrivate)           | Asserts that a value is private.                   |
+| [concat](/content/functions/concat)                         | Concatenates two arrays.                           |
+| [dataLength](/content/functions/dataLength)                 | Gets the length of a data array.                   |
+| [dataSlice](/content/functions/dataSlice)                   | Slices a data array.                               |
+| [defineProperties](/content/functions/defineProperties)     | Defines properties on an object.                   |
+| [formatEther](/content/functions/formatEther)               | Formats a value in ether.                          |
+| [formatQuai](/content/functions/formatQuai)                 | Formats a value in quai.                           |
+| [formatUnits](/content/functions/formatUnits)               | Formats a value in units.                          |
+| [fromTwos](/content/functions/fromTwos)                     | Converts a two's complement value to a big number. |
+| [getAddressDetails](/content/functions/getAddressDetails)   | Gets details about an address.                     |
+| [getBigInt](/content/functions/getBigInt)                   | Gets a big integer.                                |
+| [getBytes](/content/functions/getBytes)                     | Gets a bytes array.                                |
+| [getBytesCopy](/content/functions/getBytesCopy)             | Gets a copy of a bytes array.                      |
+| [getNumber](/content/functions/getNumber)                   | Gets a number.                                     |
+| [getShardForAddress](/content/functions/getShardForAddress) | Gets the shard for an address.                     |
+| [getTxType](/content/functions/getTxType)                   | Gets the type of a transaction.                    |
+| [hexlify](/content/functions/hexlify)                       | Converts a value to a hex string.                  |
+| [isBytesLike](/content/functions/isBytesLike)               | Checks if a value is bytes-like.                   |
+| [isCallException](/content/functions/isCallException)       | Checks if a value is a call exception.             |
+| [isError](/content/functions/isError)                       | Checks if a value is an error.                     |
+| [isHexString](/content/functions/isHexString)               | Checks if a value is a hex string.                 |
+| [isQiAddress](/content/functions/isQiAddress)               | Checks if a value is a Qi address.                 |
+| [makeError](/content/functions/makeError)                   | Makes an error.                                    |
+| [mask](/content/functions/mask)                             | Masks a value.                                     |
+| [parseEther](/content/functions/parseEther)                 | Parses a value in ether.                           |
+| [parseQuai](/content/functions/parseQuai)                   | Parses a value in quai.                            |
+| [parseUnits](/content/functions/parseUnits)                 | Parses a value in units.                           |
+| [resolveProperties](/content/functions/resolveProperties)   | Resolves properties on an object.                  |
+| [stripZerosLeft](/content/functions/stripZerosLeft)         | Strips zeros from the left of a value.             |
+| [toBeArray](/content/functions/toBeArray)                   | Checks if a value is an array.                     |
+| [toBeHex](/content/functions/toBeHex)                       | Checks if a value is a hex string.                 |
+| [toBigInt](/content/functions/toBigInt)                     | Converts a value to a big integer.                 |
+| [toNumber](/content/functions/toNumber)                     | Converts a value to a number.                      |
+| [toQuantity](/content/functions/toQuantity)                 | Converts a value to a quantity.                    |
+| [toTwos](/content/functions/toTwos)                         | Converts a value to two's complement.              |
+| [uuidV4](/content/functions/uuidV4)                         | Generates a UUID v4.                               |
+| [zeroPadBytes](/content/functions/zeroPadBytes)             | Zero-pads a bytes array.                           |
+| [zeroPadValue](/content/functions/zeroPadValue)             | Zero-pads a value.                                 |

--- a/docs/static/wallet.mdx
+++ b/docs/static/wallet.mdx
@@ -1,10 +1,40 @@
 ---
 title: Wallets
+sidebarTitle: Wallets
 description: 'A combination of generalized and low-level wallet tools.'
+icon: 'wallet'
 ---
 
 When interacting with either Qi or Quai, it is necessary to use a private key authenticate actions by signing a payload.
 
-Wallets are the simplest way to expose the concept of an Externally Owner Account (EOA) or UTXO account as it wraps a private key and supports high-level methods to sign common types of interaction and send transactions.
+**Wallets are the simplest way** to expose the concept of an Externally Owner Account (EOA) or UTXO account as it wraps a private key and supports high-level methods to sign common types of interaction and send transactions.
 
-The class most developers will want to use is Wallet, which can load a private key directly or from any common wallet format.
+The class most developers will want to use is Wallet, **which can load a private key directly or from any common wallet format**.
+
+## Classes
+
+|                                                       |                                                                      |
+| ----------------------------------------------------- | -------------------------------------------------------------------- |
+| [BaseWallet](/content/classes/BaseWallet)             | An abstract wallet class.                                            |
+| [HDNodeVoidWallet](/content/classes/HDNodeVoidWallet) | A Hierarchical Deterministic wallet that does not sign transactions. |
+| [Mnemonic](/content/classes/Mnemonic)                 | A mnemonic wallet.                                                   |
+| [QiHDWallet](/content/classes/QiHDWallet)             | A Hierarchical Deterministic wallet for the Qi network.              |
+| [QuaiHDWallet](/content/classes/QuaiHDWallet)         | A Hierarchical Deterministic wallet for the Quai network.            |
+| [Wallet](/content/classes/Wallet)                     | A wallet that can sign transactions.                                 |
+
+## Types
+
+|                                                          |                                       |
+| -------------------------------------------------------- | ------------------------------------- |
+| [EncryptOptions](/content/type-aliases/EncryptOptions)   | Options for encrypting a private key. |
+| [KeystoreAccount](/content/type-aliases/KeystoreAccount) | A keystore account.                   |
+
+## Functions
+
+|                                                                       |                                               |
+| --------------------------------------------------------------------- | --------------------------------------------- |
+| [decryptKeystoreJson](/content/functions/decryptKeystoreJson)         | Decrypt a keystore JSON object.               |
+| [decryptKeystoreJsonSync](/content/functions/decryptKeystoreJsonSync) | Decrypt a keystore JSON object synchronously. |
+| [encryptKeystoreJson](/content/functions/encryptKeystoreJson)         | Encrypt a keystore JSON object.               |
+| [encryptKeystoreJsonSync](/content/functions/encryptKeystoreJsonSync) | Encrypt a keystore JSON object synchronously. |
+| [isKeystoreJson](/content/functions/isKeystoreJson)                   | Check if a JSON object is a keystore.         |

--- a/docs/static/wordlists.mdx
+++ b/docs/static/wordlists.mdx
@@ -1,12 +1,29 @@
 ---
 title: Wordlists
+sidebarTitle: wordlists
 description: 'A collection of wordlists for use in various applications.'
+icon: 'keyboard'
 ---
 
-A Wordlist is a set of 2048 words used to encode private keys (or other binary data) that is easier for humans to write down, transcribe and dictate.
+A Wordlist is a set of 2048 words used to encode private keys (or other binary data) that is **easier for humans to write down, transcribe and dictate**.
 
 The BIP-39 standard includes several checksum bits, depending on the size of the mnemonic phrase.
 
 A mnemonic phrase may be 12, 15, 18, 21 or 24 words long. For most purposes 12 word mnemonics should be used, as including additional words increases the difficulty and potential for mistakes and does not offer any effective improvement on security.
 
-There are a variety of BIP-39 Wordlists for different languages, b
+There are a variety of BIP-39 Wordlists for different languages, *but the most common is the English wordlist*.
+
+## Classes
+
+|                                             |                                        |
+| ------------------------------------------- | -------------------------------------- |
+| [LangEn](/content/classes/LangEn)           | The English BIP-39 wordlist.           |
+| [LangEs](/content/classes/LangEs)           | The Spanish BIP-39 wordlist.           |
+| [Wordlist](/content/classes/Wordlist)       | An abstract wordlist class.            |
+| [WordlistOwl](/content/classes/WordlistOwl) | A wordlist that uses the Owl language. |
+
+## Variables
+
+|                                           |                                   |
+| ----------------------------------------- | --------------------------------- |
+| [wordlists](/content/variables/wordlists) | A set of common BIP-39 wordlists. |

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -116,18 +116,9 @@ function stringify(value: any): any {
  *
  * **`"TRANSACTION_REPLACED"`** - see {@link TransactionReplacedError | **TransactionReplacedError**}
  *
- * **`"UNCONFIGURED_NAME"`** - see {link UnconfiguredNameError | **UnconfiguredNameError**}
+ * **User Interaction Errors**
  *
- * @category Utils
- * @todo - Revise as UnconfiguredNameError has been removed
- *
- *   **`"OFFCHAIN_FAULT"`** - see {link OffchainFaultError | **OffchainFaultError**}
- *
- * @todo - Revise as OffchainFaultError has been removed
- *
- *   **User Interaction Errors**
- *
- *   **`"ACTION_REJECTED"`** - see {@link ActionRejectedError | **ActionRejectedError**}
+ * **`"ACTION_REJECTED"`** - see {@link ActionRejectedError | **ActionRejectedError**}
  */
 export type ErrorCode =
     // Generic Errors
@@ -669,7 +660,6 @@ export function isCallException(error: any): error is CallExceptionError {
  * @param {string} message - The error message.
  * @param {ErrorCode} code - The error code.
  * @param {ErrorInfo<T>} [info] - Additional properties for the error.
- *
  * @returns {T} The new error.
  */
 export function makeError<K extends ErrorCode, T extends CodedquaisError<K>>(


### PR DESCRIPTION
- Configure frontmatter plugin to add icons that indicate class, type, function, etc.
- Remove unused error configuration links that were throwing errors when migrated to docs site