### PR TITLE
Update getNextAddress method to use async/await and add synchronous counterpart

### DIFF
--- a/src/_tests/test-qi-hdwallet.ts
+++ b/src/_tests/test-qi-hdwallet.ts
@@ -25,7 +25,7 @@ describe('QiHDWallet: Test address generation and retrieval', function () {
         it(`tests addresses generation and retrieval: ${test.name}`, function () {
             const generatedAddresses: AddressInfo[] = [];
             for (const { params, expectedAddress } of test.addresses) {
-                const addrInfo = qiWallet.getNextAddress(params.account, params.zone);
+                const addrInfo = qiWallet.getNextAddressSync(params.account, params.zone);
                 assert.deepEqual(addrInfo, expectedAddress);
                 generatedAddresses.push(addrInfo);
 
@@ -60,7 +60,7 @@ describe('QiHDWallet: Test address generation and retrieval', function () {
         });
         it(`tests change addresses generation and retrieval: ${test.name}`, function () {
             for (const { params, expectedAddress } of test.changeAddresses) {
-                const addrInfo = qiWallet.getNextChangeAddress(params.account, params.zone);
+                const addrInfo = qiWallet.getNextChangeAddressSync(params.account, params.zone);
                 assert.deepEqual(addrInfo, expectedAddress);
             }
         });
@@ -76,8 +76,8 @@ describe('QiHDWallet: Test serialization and deserialization of QiHDWallet', fun
         let serialized: any;
         it(`tests serialization QuaiHDWallet: ${test.name}`, async function () {
             for (const param of test.params) {
-                qiWallet.getNextAddress(param.account, param.zone);
-                qiWallet.getNextChangeAddress(param.account, param.zone);
+                qiWallet.getNextAddressSync(param.account, param.zone);
+                qiWallet.getNextChangeAddressSync(param.account, param.zone);
             }
             qiWallet.importOutpoints(test.outpoints);
             serialized = qiWallet.serialize();
@@ -98,7 +98,7 @@ describe('QiHDWallet: Test transaction signing', function () {
             const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
             const qiWallet = QiHDWallet.fromMnemonic(mnemonic);
             for (const param of test.params) {
-                qiWallet.getNextAddress(param.account, param.zone);
+                qiWallet.getNextAddressSync(param.account, param.zone);
             }
             qiWallet.importOutpoints(test.outpoints);
             const qiTx = createQiTransaction(
@@ -130,7 +130,7 @@ describe('QiHDWallet: Test sign personal menssage', function () {
         it(`tests signing personal message: ${test.name}`, async function () {
             const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
             const qiWallet = QiHDWallet.fromMnemonic(mnemonic);
-            const addrInfo = qiWallet.getNextAddress(0, Zone.Cyprus1);
+            const addrInfo = qiWallet.getNextAddressSync(0, Zone.Cyprus1);
             const signature = await qiWallet.signMessage(addrInfo.address, test.message);
             const digest = keccak_256(test.message);
             const verified = verifySchnorrSignature(signature, digest, addrInfo.pubKey);

--- a/src/_tests/test-quai-hdwallet.ts
+++ b/src/_tests/test-quai-hdwallet.ts
@@ -24,7 +24,7 @@ describe('Test address generation and retrieval', function () {
         it(`tests addresses generation and retrieval: ${test.name}`, function () {
             const generatedAddresses: AddressInfo[] = [];
             for (const { params, expectedAddress } of test.addresses) {
-                const addrInfo = quaiWallet.getNextAddress(params.account, params.zone);
+                const addrInfo = quaiWallet.getNextAddressSync(params.account, params.zone);
                 assert.deepEqual(addrInfo, expectedAddress);
                 generatedAddresses.push(addrInfo);
 
@@ -66,7 +66,7 @@ describe('Test transaction signing', function () {
         it(`tests signing an EIP-155 transaction: ${test.name}`, async function () {
             const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
             const quaiWallet = QuaiHDWallet.fromMnemonic(mnemonic);
-            quaiWallet.getNextAddress(test.params.account, test.params.zone);
+            quaiWallet.getNextAddressSync(test.params.account, test.params.zone);
             const txData = test.transaction;
             const signed = await quaiWallet.signTransaction(txData);
             assert.equal(signed, test.signed, 'signed');
@@ -82,7 +82,7 @@ describe('Test serialization and deserialization of QuaiHDWallet', function () {
         let serialized: any;
         it(`tests serialization QuaiHDWallet: ${test.name}`, async function () {
             for (const param of test.params) {
-                quaiWallet.getNextAddress(param.account, param.zone);
+                quaiWallet.getNextAddressSync(param.account, param.zone);
             }
             serialized = quaiWallet.serialize();
             assert.deepEqual(serialized, test.serialized);
@@ -101,7 +101,7 @@ describe('Test Typed-Data Signing (EIP-712)', function () {
         it(`tests signing typed-data: ${test.name}`, async function () {
             const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
             const quaiWallet = QuaiHDWallet.fromMnemonic(mnemonic);
-            const addrInfo = quaiWallet.getNextAddress(0, Zone.Cyprus1);
+            const addrInfo = quaiWallet.getNextAddressSync(0, Zone.Cyprus1);
             const sig = await quaiWallet.signTypedData(addrInfo.address, test.domain, test.types, test.data);
             assert.equal(sig, test.signature, 'signature');
             const signerAddress = recoverAddress(test.digest, sig);
@@ -116,7 +116,7 @@ describe('Test sign message', function () {
         it(`tests signing personal message: ${test.name}`, async function () {
             const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
             const quaiWallet = QuaiHDWallet.fromMnemonic(mnemonic);
-            const addrInfo = quaiWallet.getNextAddress(0, Zone.Cyprus1);
+            const addrInfo = quaiWallet.getNextAddressSync(0, Zone.Cyprus1);
             const sig = await quaiWallet.signMessage(addrInfo.address, test.message);
             assert.equal(sig, test.signature, 'signature');
             const signerAddress = recoverAddress(test.digest, sig);

--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -186,13 +186,24 @@ export abstract class AbstractHDWallet {
     }
 
     /**
-     * Retrieves the next address for the specified account and zone.
+     * Promise that resolves to the next address for the specified account and zone.
+     *
+     * @param {number} account - The index of the account for which to retrieve the next address.
+     * @param {Zone} zone - The zone in which to retrieve the next address.
+     * @returns {Promise<NeuteredAddressInfo>} The next neutered address information.
+     */
+    public async getNextAddress(account: number, zone: Zone): Promise<NeuteredAddressInfo> {
+        return Promise.resolve(this._getNextAddress(account, zone, false, this._addresses));
+    }
+
+    /**
+     * Synchronously retrieves the next address for the specified account and zone.
      *
      * @param {number} account - The index of the account for which to retrieve the next address.
      * @param {Zone} zone - The zone in which to retrieve the next address.
      * @returns {NeuteredAddressInfo} The next neutered address information.
      */
-    public getNextAddress(account: number, zone: Zone): NeuteredAddressInfo {
+    public getNextAddressSync(account: number, zone: Zone): NeuteredAddressInfo {
         return this._getNextAddress(account, zone, false, this._addresses);
     }
 

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -60,7 +60,7 @@ interface SerializedQiHDWallet extends SerializedHDWallet {
  * import { QiHDWallet, Zone } from 'quais';
  *
  * const wallet = new QiHDWallet();
- * const cyrpus1Address = wallet.getNextAddress(0, Zone.Cyrpus1); // get the first address in the Cyrpus1 zone
+ * const cyrpus1Address = await wallet.getNextAddress(0, Zone.Cyrpus1); // get the first address in the Cyrpus1 zone
  * await wallet.sendTransaction({ txInputs: [...], txOutputs: [...] }); // send a transaction
  * const serializedWallet = wallet.serialize(); // serialize current (account/address) state of the wallet
  * .
@@ -130,13 +130,24 @@ export class QiHDWallet extends AbstractHDWallet {
     }
 
     /**
-     * Retrieves the next change address for the specified account and zone.
+     * Promise that resolves to the next change address for the specified account and zone.
+     *
+     * @param {number} account - The index of the account for which to retrieve the next change address.
+     * @param {Zone} zone - The zone in which to retrieve the next change address.
+     * @returns {Promise<NeuteredAddressInfo>} The next change neutered address information.
+     */
+    public async getNextChangeAddress(account: number, zone: Zone): Promise<NeuteredAddressInfo> {
+        return Promise.resolve(this._getNextAddress(account, zone, true, this._changeAddresses));
+    }
+
+    /**
+     * Synchronously retrieves the next change address for the specified account and zone.
      *
      * @param {number} account - The index of the account for which to retrieve the next change address.
      * @param {Zone} zone - The zone in which to retrieve the next change address.
      * @returns {NeuteredAddressInfo} The next change neutered address information.
      */
-    public getNextChangeAddress(account: number, zone: Zone): NeuteredAddressInfo {
+    public getNextChangeAddressSync(account: number, zone: Zone): NeuteredAddressInfo {
         return this._getNextAddress(account, zone, true, this._changeAddresses);
     }
 
@@ -314,7 +325,7 @@ export class QiHDWallet extends AbstractHDWallet {
      * until the gap limit is reached for both gap and change addresses.
      *
      * @param {Zone} zone - The zone in which to scan for addresses.
-     * @param {number} [account=0] - The index of the account to scan. Default is `0`.
+     * @param {number} [account=0] - The index of the account to scan. Default is `0`
      * @returns {Promise<void>} A promise that resolves when the scan is complete.
      * @throws {Error} If the zone is invalid.
      */

--- a/src/wallet/quai-hdwallet.ts
+++ b/src/wallet/quai-hdwallet.ts
@@ -27,7 +27,7 @@ import { TypedDataDomain, TypedDataField } from '../hash/index.js';
  * import { QuaiHDWallet, Zone } from 'quais';
  *
  * const wallet = new QuaiHDWallet();
- * const cyrpus1Address = wallet.getNextAddress(0, Zone.Cyrpus1); // get the first address in the Cyrpus1 zone
+ * const cyrpus1Address = await wallet.getNextAddress(0, Zone.Cyrpus1); // get the first address in the Cyrpus1 zone
  * await wallet.sendTransaction({ from: address, to: '0x...', value: 100 }); // send a transaction
  * const serializedWallet = wallet.serialize(); // serialize current (account/address) state of the wallet
  * .
@@ -67,7 +67,6 @@ export class QuaiHDWallet extends AbstractHDWallet {
      * Sign a transaction.
      *
      * @param {QuaiTransactionRequest} tx - The transaction request.
-     *
      * @returns {Promise<string>} A promise that resolves to the signed transaction.
      */
     public async signTransaction(tx: QuaiTransactionRequest): Promise<string> {
@@ -81,7 +80,6 @@ export class QuaiHDWallet extends AbstractHDWallet {
      * Send a transaction.
      *
      * @param {QuaiTransactionRequest} tx - The transaction request.
-     *
      * @returns {Promise<TransactionResponse>} A promise that resolves to the transaction response.
      * @throws {Error} If the provider is not set.
      */
@@ -100,7 +98,6 @@ export class QuaiHDWallet extends AbstractHDWallet {
      *
      * @param {string} address - The address.
      * @param {string | Uint8Array} message - The message to sign.
-     *
      * @returns {Promise<string>} A promise that resolves to the signed message.
      */
     public async signMessage(address: string, message: string | Uint8Array): Promise<string> {
@@ -113,7 +110,6 @@ export class QuaiHDWallet extends AbstractHDWallet {
      *
      * @async
      * @param {SerializedHDWallet} serialized - The serialized wallet data to be deserialized.
-     *
      * @returns {Promise<QuaiHDWallet>} A promise that resolves to an instance of QuaiHDWallet.
      * @throws {Error} If validation of the serialized wallet data fails or if deserialization fails.
      * @public
@@ -141,7 +137,6 @@ export class QuaiHDWallet extends AbstractHDWallet {
      * @param {Record<string, TypedDataField[]>} types - The types of the data to be signed, mapping each data type name
      *   to its fields.
      * @param {Record<string, unknown>} value - The actual data to be signed.
-     *
      * @returns {Promise<string>} A promise that resolves to the signed data in string format.
      * @throws {Error} If the address does not correspond to a valid HD node or if signing fails.
      */


### PR DESCRIPTION
Tests were updated to use sync methods so the updated `getNextAddress` and `getNextChangeAddress` are not covered in unit tests. We can update tests to include these in the near future as they were skipped in favor of getting a release out today.