### PR TITLE
Jsdoc fixes

### DIFF
--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -3,8 +3,6 @@
  * decoded, and how to decode events and errors.
  *
  * See [About ABIs](docs-abi) for more details how they are used.
- *
- * @todo LINK TO: [[docs-abi]] (abi.wrm file)
  */
 
 export { AbiCoder } from './abi-coder.js';

--- a/src/address/address.ts
+++ b/src/address/address.ts
@@ -58,12 +58,10 @@ export function formatMixedCaseChecksumAddress(address: string): string {
  * ```js
  * // Adds the checksum (via upper-casing specific letters)
  * getAddress('0x8ba1f109551bd432803012645ac136ddd64dba72');
- * //_result:
  *
  * // Throws an error if an address contains mixed case,
  * // but the checksum fails
  * getAddress('0x8Ba1f109551bD432803012645Ac136ddd64DBA72');
- * //_error:
  * ```
  */
 export function getAddress(address: string): string {
@@ -104,7 +102,6 @@ export function getContractAddress(from: string, nonce: BigNumberish, data: Byte
  *
  * @category Address
  * @param {string | SigningKey} key - The key to compute the address for.
- *
  * @returns {string} The address.
  */
 export function computeAddress(key: string | SigningKey): string {
@@ -123,7 +120,6 @@ export function computeAddress(key: string | SigningKey): string {
  * @category Address
  * @param {BytesLike} digest - The digest of the message.
  * @param {SignatureLike} signature - The signature.
- *
  * @returns {string} The address.
  */
 export function recoverAddress(digest: BytesLike, signature: SignatureLike): string {

--- a/src/address/checks.ts
+++ b/src/address/checks.ts
@@ -13,12 +13,10 @@ import type { Addressable, AddressLike } from './index.js';
  * ```js
  * // Wallets and AbstractSigner sub-classes
  * isAddressable(Wallet.createRandom());
- * //_result:
  *
  * // Contracts
  * contract = new Contract('0x643aA0A61eADCC9Cc202D1915D942d35D005400C', [], provider);
  * isAddressable(contract);
- * //_result:
  * ```
  *
  * @param {any} value - The value to check.
@@ -37,11 +35,9 @@ export function isAddressable(value: any): value is Addressable {
  * ```js
  * // Valid address
  * isAddress('0x8ba1f109551bD432803012645Ac136ddd64DBA72');
- * //_result:
  *
  * // Invalid checksum
  * isAddress('0x8Ba1f109551bD432803012645Ac136ddd64DBa72');
- * //_result:
  * ```
  *
  * @param {any} value - The value to check.
@@ -76,16 +72,13 @@ async function checkAddress(target: any, promise: Promise<null | string>): Promi
  *
  * // Addresses are return synchronously
  * resolveAddress(addr, provider);
- * //_result:
  *
  * // Address promises are resolved asynchronously
  * resolveAddress(Promise.resolve(addr));
- * //_result:
  *
  * // Addressable objects are resolved asynchronously
  * contract = new Contract(addr, []);
  * resolveAddress(contract, provider);
- * //_result:
  * ```
  *
  * @param {AddressLike} target - The target to resolve to an address.

--- a/src/address/checks.ts
+++ b/src/address/checks.ts
@@ -22,7 +22,6 @@ import type { Addressable, AddressLike } from './index.js';
  * ```
  *
  * @param {any} value - The value to check.
- *
  * @returns {boolean} True if the value is an Addressable.
  */
 export function isAddressable(value: any): value is Addressable {
@@ -46,7 +45,6 @@ export function isAddressable(value: any): value is Addressable {
  * ```
  *
  * @param {any} value - The value to check.
- *
  * @returns {boolean} True if the value is a valid address.
  */
 export function isAddress(value: any): value is string {
@@ -91,9 +89,7 @@ async function checkAddress(target: any, promise: Promise<null | string>): Promi
  * ```
  *
  * @param {AddressLike} target - The target to resolve to an address.
- *
  * @returns {string | Promise<string>} The resolved address.
- * @todo Revise this method as UnconfiguredNameError has been removed
  */
 export function resolveAddress(target: AddressLike): string | Promise<string> {
     if (typeof target === 'string') {
@@ -114,7 +110,6 @@ export function resolveAddress(target: AddressLike): string | Promise<string> {
  *
  * @category Address
  * @param address - The address to validate.
- *
  * @returns True if the address is a valid mixed case checksummed address.
  */
 export function validateAddress(address: string): void {
@@ -133,7 +128,6 @@ export function validateAddress(address: string): void {
  *
  * @category Address
  * @param {string} address - The address to check
- *
  * @returns {boolean} True if the address is in the Qi ledger scope, false otherwise.
  */
 export function isQiAddress(address: string): boolean {
@@ -149,7 +143,6 @@ export function isQiAddress(address: string): boolean {
  *
  * @category Address
  * @param {string} address - The address to check
- *
  * @returns {boolean} True if the address is in the Quai ledger scope, false otherwise.
  */
 export function isQuaiAddress(address: string): boolean {

--- a/src/address/contract-address.ts
+++ b/src/address/contract-address.ts
@@ -24,7 +24,6 @@ import type { BigNumberish, BytesLike } from '../utils/index.js';
  * nonce = 5;
  *
  * getCreateAddress({ from, nonce });
- * //_result:
  * ```
  *
  * @param {object} tx - The transaction object.
@@ -68,7 +67,6 @@ export function getCreateAddress(tx: { from: string; nonce: BigNumberish; data: 
  * initCodeHash = keccak256(initCode);
  *
  * getCreate2Address(from, salt, initCodeHash);
- * //_result:
  * ```
  *
  * @param {string} _from - The address of the sender.

--- a/src/crypto/hmac.ts
+++ b/src/crypto/hmac.ts
@@ -27,18 +27,15 @@ let __computeHmac = _computeHmac;
  *
  * // Compute the HMAC
  * computeHmac('sha256', key, '0x1337');
- * //_result:
  *
  * // To compute the HMAC of UTF-8 data, the data must be
  * // converted to UTF-8 bytes
  * computeHmac('sha256', key, toUtf8Bytes('Hello World'));
- * //_result:
  * ```
  *
  * @param {'sha256' | 'sha512'} algorithm - The algorithm to use for compression.
  * @param {BytesLike} _key - The key to use for the HMAC.
  * @param {BytesLike} _data - The data to authenticate.
- *
  * @returns {string} The HMAC of the data.
  */
 export function computeHmac(algorithm: 'sha256' | 'sha512', _key: BytesLike, _data: BytesLike): string {

--- a/src/crypto/keccak.ts
+++ b/src/crypto/keccak.ts
@@ -27,22 +27,17 @@ let __keccak256: (data: Uint8Array) => BytesLike = _keccak256;
  *
  * ```ts
  * keccak256('0x');
- * //_result:
  *
  * keccak256('0x1337');
- * //_result:
  *
  * keccak256(new Uint8Array([0x13, 0x37]));
- * //_result:
  *
  * // Strings are assumed to be DataHexString, otherwise it will
  * // throw. To hash UTF-8 data, see the note above.
  * keccak256('Hello World');
- * //_error:
  * ```
  *
  * @param {BytesLike} _data - The data to hash.
- *
  * @returns DataHexstring
  * @returns {string} The hash of the data.
  */

--- a/src/crypto/pbkdf2.ts
+++ b/src/crypto/pbkdf2.ts
@@ -43,7 +43,6 @@ let __pbkdf2 = _pbkdf2;
  *
  * // Compute the PBKDF2
  * pbkdf2(passwordBytes, salt, 1024, 16, 'sha256');
- * //_result:
  * ```
  *
  * @param {BytesLike} _password - The password to use.
@@ -51,7 +50,6 @@ let __pbkdf2 = _pbkdf2;
  * @param {number} iterations - The number of iterations to use.
  * @param {number} keylen - The length of the key to generate.
  * @param {'sha256' | 'sha512'} algo - The algorithm to use.
- *
  * @returns {string} The key derived from the password.
  */
 export function pbkdf2(

--- a/src/crypto/random.ts
+++ b/src/crypto/random.ts
@@ -21,11 +21,9 @@ let __randomBytes = _randomBytes;
  *
  * ```ts
  * randomBytes(8);
- * //_result:
  * ```
  *
  * @param {number} length - The number of bytes to generate.
- *
  * @returns {Uint8Array} The random bytes.
  */
 export function randomBytes(length: number): Uint8Array {

--- a/src/crypto/ripemd160.ts
+++ b/src/crypto/ripemd160.ts
@@ -20,17 +20,13 @@ let __ripemd160: (data: Uint8Array) => BytesLike = _ripemd160;
  *
  * ```ts
  * ripemd160('0x');
- * //_result:
  *
  * ripemd160('0x1337');
- * //_result:
  *
  * ripemd160(new Uint8Array([0x13, 0x37]));
- * //_result:
  * ```
  *
  * @param {BytesLike} _data - The data to hash.
- *
  * @returns DataHexstring
  * @returns {string} The hash of the data.
  */

--- a/src/crypto/scrypt.ts
+++ b/src/crypto/scrypt.ts
@@ -74,7 +74,6 @@ let __scryptSync: (passwd: Uint8Array, salt: Uint8Array, N: number, r: number, p
  *
  * // Compute the scrypt
  * scrypt(passwordBytes, salt, 1024, 8, 1, 16);
- * //_result:
  * ```
  *
  * @param {BytesLike} _passwd - The password to use.
@@ -84,7 +83,6 @@ let __scryptSync: (passwd: Uint8Array, salt: Uint8Array, N: number, r: number, p
  * @param {number} p - The parallelization parameter.
  * @param {number} dkLen - The length of the key to generate.
  * @param {ProgressCallback} [progress] - A callback to update the progress.
- *
  * @returns {Promise<string>} The key derived from the password.
  */
 export async function scrypt(
@@ -142,7 +140,6 @@ Object.freeze(scrypt);
  *
  * // Compute the scrypt
  * scryptSync(passwordBytes, salt, 1024, 8, 1, 16);
- * //_result:
  * ```
  *
  * @param {BytesLike} _passwd - The password to use.
@@ -151,7 +148,6 @@ Object.freeze(scrypt);
  * @param {number} r - The block size parameter.
  * @param {number} p - The parallelization parameter.
  * @param {number} dkLen - The length of the key to generate.
- *
  * @returns {string} The key derived from the password.
  */
 export function scryptSync(

--- a/src/crypto/sha2.ts
+++ b/src/crypto/sha2.ts
@@ -26,17 +26,13 @@ let locked256 = false,
  *
  * ```ts
  * sha256('0x');
- * //_result:
  *
  * sha256('0x1337');
- * //_result:
  *
  * sha256(new Uint8Array([0x13, 0x37]));
- * //_result:
  * ```
  *
  * @param {BytesLike} _data - The data to hash.
- *
  * @returns {string} The hash of the data.
  */
 export function sha256(_data: BytesLike): string {
@@ -63,17 +59,13 @@ Object.freeze(sha256);
  *
  * ```ts
  * sha512('0x');
- * //_result:
  *
  * sha512('0x1337');
- * //_result:
  *
  * sha512(new Uint8Array([0x13, 0x37]));
- * //_result:
  * ```
  *
  * @param {BytesLike} _data - The data to hash.
- *
  * @returns {string} The hash of the data.
  */
 export function sha512(_data: BytesLike): string {

--- a/src/crypto/signature.ts
+++ b/src/crypto/signature.ts
@@ -216,14 +216,11 @@ export class Signature {
      *
      * ```ts
      * Signature.getChainId(45);
-     * //_result:
      *
      * Signature.getChainId(46);
-     * //_result:
      * ```
      *
      * @param {BigNumberish} v - The `v` value from the signature.
-     *
      * @returns {bigint} The chain ID.
      */
     static getChainId(v: BigNumberish): bigint {
@@ -250,15 +247,12 @@ export class Signature {
      *
      * ```ts
      * Signature.getChainIdV(5, 27);
-     * //_result:
      *
      * Signature.getChainIdV(5, 28);
-     * //_result:
      * ```
      *
      * @param {BigNumberish} chainId - The chain ID.
      * @param {27 | 28} v - The `v` value.
-     *
      * @returns {bigint} The `v` value.
      */
     static getChainIdV(chainId: BigNumberish, v: 27 | 28): bigint {
@@ -274,23 +268,18 @@ export class Signature {
      * ```ts
      * // The values 0 and 1 imply v is actually yParity
      * Signature.getNormalizedV(0);
-     * //_result:
      *
      * // Legacy non-EIP-1559 transaction (i.e. 27 or 28)
      * Signature.getNormalizedV(27);
-     * //_result:
      *
      * // Legacy EIP-155 transaction (i.e. >= 35)
      * Signature.getNormalizedV(46);
-     * //_result:
      *
      * // Invalid values throw
      * Signature.getNormalizedV(5);
-     * //_error:
      * ```
      *
      * @param {BigNumberish} v - The `v` value.
-     *
      * @returns {27 | 28} The normalized `v` value.
      * @throws {Error} Thrown if the `v` is invalid.
      */
@@ -318,7 +307,6 @@ export class Signature {
      * If `sig` is a string, it is parsed.
      *
      * @param {SignatureLike} [sig] - The signature to create.
-     *
      * @returns {Signature} The new signature.
      */
     static from(sig?: SignatureLike): Signature {

--- a/src/crypto/signing-key.ts
+++ b/src/crypto/signing-key.ts
@@ -59,7 +59,6 @@ export class SigningKey {
      * Return the signature of the signed `digest`.
      *
      * @param {BytesLike} digest - The data to sign.
-     *
      * @returns {Signature} The signature of the data.
      * @throws {Error} If the digest is not 32 bytes long.
      */
@@ -93,15 +92,12 @@ export class SigningKey {
      *
      * // Notice that privA.computeSharedSecret(pubB)...
      * sign1.computeSharedSecret(sign2.publicKey);
-     * //_result:
      *
      * // ...is equal to privB.computeSharedSecret(pubA).
      * sign2.computeSharedSecret(sign1.publicKey);
-     * //_result:
      * ```
      *
      * @param {BytesLike} other - The other key to compute the shared secret with.
-     *
      * @returns {string} The shared secret.
      */
     computeSharedSecret(other: BytesLike): string {
@@ -121,24 +117,19 @@ export class SigningKey {
      *
      * // Compute the uncompressed public key for a private key
      * SigningKey.computePublicKey(sign.privateKey);
-     * //_result:
      *
      * // Compute the compressed public key for a private key
      * SigningKey.computePublicKey(sign.privateKey, true);
-     * //_result:
      *
      * // Compute the uncompressed public key
      * SigningKey.computePublicKey(sign.publicKey, false);
-     * //_result:
      *
      * // Compute the Compressed a public key
      * SigningKey.computePublicKey(sign.publicKey, true);
-     * //_result:
      * ```
      *
      * @param {BytesLike} key - The key to compute the public key for.
      * @param {boolean} [compressed] - Whether to return the compressed public key.
-     *
      * @returns {string} The public key.
      */
     static computePublicKey(key: BytesLike, compressed?: boolean): string {
@@ -174,16 +165,13 @@ export class SigningKey {
      *
      * // Notice the signer public key...
      * key.publicKey;
-     * //_result:
      *
      * // ...is equal to the recovered public key
      * SigningKey.recoverPublicKey(digest, sig);
-     * //_result:
      * ```
      *
      * @param {BytesLike} digest - The data that was signed.
      * @param {SignatureLike} signature - The signature of the data.
-     *
      * @returns {string} The public key.
      */
     static recoverPublicKey(digest: BytesLike, signature: SignatureLike): string {
@@ -212,7 +200,6 @@ export class SigningKey {
      * @param {BytesLike} p0 - The first point to add.
      * @param {BytesLike} p1 - The second point to add.
      * @param {boolean} [compressed] - Whether to return the compressed public key.
-     *
      * @returns {string} The sum of the points.
      */
     static addPoints(p0: BytesLike, p1: BytesLike, compressed?: boolean): string {

--- a/src/encoding/base64.ts
+++ b/src/encoding/base64.ts
@@ -16,19 +16,15 @@ import type { BytesLike } from '../utils/data.js';
  * ```ts
  * // The decoded value is always binary data...
  * result = decodeBase64('SGVsbG8gV29ybGQhIQ==');
- * //_result:
  *
  * // ...use toUtf8String to convert it to a string.
  * toUtf8String(result);
- * //_result:
  *
  * // Decoding binary data
  * decodeBase64('EjQ=');
- * //_result:
  * ```
  *
  * @param {string} value - The base-64 encoded value.
- *
  * @returns {Uint8Array} The decoded binary data.
  */
 export function decodeBase64(value: string): Uint8Array {
@@ -44,23 +40,18 @@ export function decodeBase64(value: string): Uint8Array {
  * ```ts
  * // Encoding binary data as a hexstring
  * encodeBase64('0x1234');
- * //_result:
  *
  * // Encoding binary data as a Uint8Array
  * encodeBase64(new Uint8Array([0x12, 0x34]));
- * //_result:
  *
  * // The input MUST be data...
  * encodeBase64('Hello World!!');
- * //_error:
  *
  * // ...use toUtf8Bytes for this.
  * encodeBase64(toUtf8Bytes('Hello World!!'));
- * //_result:
  * ```
  *
  * @param {BytesLike} data - The data to encode.
- *
  * @returns {string} The base-64 encoded string.
  */
 export function encodeBase64(data: BytesLike): string {

--- a/src/encoding/proto-decode.ts
+++ b/src/encoding/proto-decode.ts
@@ -4,10 +4,8 @@ import * as Proto from './protoc/proto_block.js';
 
 /**
  * @category Encoding
- * @param {Uint8Array} bytes - Write variable description
- *
- * @returns {ProtoTransaction} Write return description
- * @todo Write documentation for this function.
+ * @param {Uint8Array} bytes - The Protobuf encoded transaction
+ * @returns {ProtoTransaction} - The decoded transaction
  */
 export function decodeProtoTransaction(bytes: Uint8Array): ProtoTransaction {
     const tx = Proto.block.ProtoTransaction.deserialize(bytes);
@@ -20,10 +18,8 @@ export function decodeProtoTransaction(bytes: Uint8Array): ProtoTransaction {
 
 /**
  * @category Encoding
- * @param {Uint8Array} bytes - Write variable description
- *
- * @returns {ProtoWorkObject} Write return description
- * @todo Write documentation for this function.
+ * @param {Uint8Array} bytes - The Protobuf encoded work object
+ * @returns {ProtoWorkObject} - The decoded work object
  */
 export function decodeProtoWorkObject(bytes: Uint8Array): ProtoWorkObject {
     const wo = Proto.block.ProtoWorkObject.deserialize(bytes);

--- a/src/encoding/proto-encode.ts
+++ b/src/encoding/proto-encode.ts
@@ -5,10 +5,8 @@ import * as Proto from './protoc/proto_block.js';
 
 /**
  * @category Encoding
- * @param {ProtoTransaction} protoTx - Write variable description
- *
- * @returns {string} Write return description
- * @todo Write documentation for this function.
+ * @param {ProtoTransaction} protoTx - The signed constructed transaction
+ * @returns {string} - The Protobuf encoded transaction
  */
 export function encodeProtoTransaction(protoTx: ProtoTransaction): string {
     const tx = Proto.block.ProtoTransaction.fromObject(protoTx as any);
@@ -17,10 +15,8 @@ export function encodeProtoTransaction(protoTx: ProtoTransaction): string {
 
 /**
  * @category Encoding
- * @param {ProtoWorkObject} protoWo - Write variable description
- *
- * @returns {string} Write return description
- * @todo Write documentation for this function.
+ * @param {ProtoWorkObject} protoWo - The constructed WorkObject
+ * @returns {string} - The Protobuf encoded WorkObject
  */
 export function encodeProtoWorkObject(protoWo: ProtoWorkObject): string {
     const wo = Proto.block.ProtoWorkObject.fromObject(protoWo as any);

--- a/src/hash/id.ts
+++ b/src/hash/id.ts
@@ -11,11 +11,9 @@ import { toUtf8Bytes } from '../encoding/index.js';
  *
  * ```ts
  * id('hello world');
- * //_result:
  * ```
  *
  * @param {string} value - The string to hash.
- *
  * @returns {string} The 32-byte identifier.
  */
 export function id(value: string): string {

--- a/src/hash/message.ts
+++ b/src/hash/message.ts
@@ -21,20 +21,16 @@ import { EthMessagePrefix } from '../constants/strings.js';
  *
  * ```ts
  * hashMessage('Hello World');
- * //_result:
  *
  * // Hashes the SIX (6) string characters, i.e.
  * // [ "0", "x", "4", "2", "4", "3" ]
  * hashMessage('0x4243');
- * //_result:
  *
  * // Hashes the TWO (2) bytes [ 0x42, 0x43 ]...
  * hashMessage(getBytes('0x4243'));
- * //_result:
  *
  * // ...which is equal to using data
  * hashMessage(new Uint8Array([0x42, 0x43]));
- * //_result:
  * ```
  *
  * @param {Uint8Array | string} message - The message to hash.

--- a/src/hash/solidity.ts
+++ b/src/hash/solidity.ts
@@ -101,12 +101,10 @@ function _pack(type: string, value: any, isArray?: boolean): Uint8Array {
  * ```ts
  * addr = '0x8ba1f109551bd432803012645ac136ddd64dba72';
  * solidityPacked(['address', 'uint'], [addr, 45]);
- * //_result:
  * ```
  *
  * @param {string[]} types - The types of the values.
  * @param {ReadonlyArray<any>} values - The values to pack.
- *
  * @returns {string} The packed values.
  */
 export function solidityPacked(types: ReadonlyArray<string>, values: ReadonlyArray<any>): string {
@@ -135,12 +133,10 @@ export function solidityPacked(types: ReadonlyArray<string>, values: ReadonlyArr
  * ```ts
  * addr = '0x8ba1f109551bd432803012645ac136ddd64dba72';
  * solidityPackedKeccak256(['address', 'uint'], [addr, 45]);
- * //_result:
  * ```
  *
  * @param {ReadonlyArray<string>} types - The types of the values.
  * @param {ReadonlyArray<any>} values - The values to hash.
- *
  * @returns {string} The hash of the packed values.
  */
 export function solidityPackedKeccak256(types: ReadonlyArray<string>, values: ReadonlyArray<any>): string {
@@ -158,12 +154,10 @@ export function solidityPackedKeccak256(types: ReadonlyArray<string>, values: Re
  * ```ts
  * addr = '0x8ba1f109551bd432803012645ac136ddd64dba72';
  * solidityPackedSha256(['address', 'uint'], [addr, 45]);
- * //_result:
  * ```
  *
  * @param {ReadonlyArray<string>} types - The types of the values.
  * @param {ReadonlyArray<any>} values - The values to hash.
- *
  * @returns {string} The hash of the packed values.
  */
 export function solidityPackedSha256(types: ReadonlyArray<string>, values: ReadonlyArray<any>): string {

--- a/src/providers/abstract-provider.ts
+++ b/src/providers/abstract-provider.ts
@@ -5,10 +5,10 @@
  */
 
 /**
- * @todo Event coalescence When we register an event with an async value (e.g. address is a Signer), we need to add it
- *   immediately for the Event API, but also need time to resolve the address. Upon resolving the address, we need to
- *   migrate the listener to the static event. We also need to maintain a map of Signer to address so we can sync
- *   respond to listenerCount.
+ * Event coalescence When we register an event with an async value (e.g. address is a Signer), we need to add it
+ * immediately for the Event API, but also need time to resolve the address. Upon resolving the address, we need to
+ * migrate the listener to the static event. We also need to maintain a map of Signer to address so we can sync respond
+ * to listenerCount.
  */
 
 import { computeAddress, resolveAddress } from '../address/index.js';
@@ -237,9 +237,7 @@ export class UnmanagedSubscriber implements Subscriber {
     start(): void {}
     stop(): void {}
 
-    /**
-     * @todo `dropWhilePaused` is not used, remove or re-write
-     */
+    // todo `dropWhilePaused` is not used, remove or re-write
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     pause(dropWhilePaused?: boolean): void {}
     resume(): void {}
@@ -278,9 +276,7 @@ function concisify(items: Array<string>): Array<string> {
     return items;
 }
 
-/**
- * @todo `provider` is not used, remove or re-write
- */
+// todo `provider` is not used, remove or re-write
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function getSubscription(_event: ProviderEvent, provider: AbstractProvider<any>): Promise<Subscription> {
     if (_event == null) {
@@ -403,8 +399,8 @@ export type PerformActionTransaction = QuaiPerformActionTransaction | QiPerformA
 
 /**
  * @category Providers
- * @todo Write documentation for this interface
  */
+// todo: write docs for this
 export interface QuaiPerformActionTransaction extends QuaiPreparedTransactionRequest {
     /**
      * The `to` address of the transaction.
@@ -421,8 +417,8 @@ export interface QuaiPerformActionTransaction extends QuaiPreparedTransactionReq
 
 /**
  * @category Providers
- * @todo Write documentation for this interface
  */
+// todo: write docs for this
 export interface QiPerformActionTransaction extends QiPreparedTransactionRequest {
     /**
      * The `inputs` of the UTXO transaction.
@@ -1719,7 +1715,6 @@ export class AbstractProvider<C = FetchRequest> implements Provider {
      * @ignore
      * @param {Subscriber} oldSub - The subscriber to replace.
      * @param {Subscriber} newSub - The new subscriber.
-     * @todo PollingEventSubscriber is not longer exported, replace this link or
      */
     _recoverSubscriber(oldSub: Subscriber, newSub: Subscriber): void {
         for (const sub of this.#subs.values()) {

--- a/src/providers/formatting.ts
+++ b/src/providers/formatting.ts
@@ -126,71 +126,73 @@ export interface LogParams {
 
 /**
  * @category Providers
- * @todo Write documentation for this interface.
+ *
+ *   **EtxParams** encodes the minimal required properties for a formatted etx.
  */
 export interface EtxParams {
     /**
-     * @todo Write documentation for this property.
+     * The transaction type for this etx. Etxs are always type 1.
      */
     type: number;
 
     /**
-     * @todo Write documentation for this property.
+     * The nonce of the etx, used for replay protection.
      */
     nonce: number;
 
     /**
-     * @todo Write documentation for this property.
+     * The actual gas price per gas charged for this etx.
      */
     gasPrice: null | bigint;
 
     /**
-     * @todo Write documentation for this property.
+     * The maximum priority fee to allow a producer to claim.
      */
     maxPriorityFeePerGas: bigint;
 
     /**
-     * @todo Write documentation for this property.
+     * The maximum fee that will be paid.
      */
     maxFeePerGas: bigint;
 
     /**
-     * @todo Write documentation for this property.
+     * The gas supplied for this etx.
      */
     gas: bigint;
 
     /**
-     * @todo Write documentation for this property.
+     * The etx value (in wei).
      */
     value: bigint;
 
     /**
-     * @todo Write documentation for this property.
+     * The input data for this etx.
      */
     input: string;
 
     /**
-     * @todo Write documentation for this property.
+     * The target of the transaction. If `null`, the `data` is initcode and this transaction is a deployment
+     * transaction.
      */
     to: null | string;
 
     /**
-     * @todo Write documentation for this property.
+     * The etx access list.
      */
     accessList: null | AccessList;
 
     /**
-     * @todo Write documentation for this property.
+     * The chain ID this etx is valid on.
      */
     chainId: null | bigint;
 
     /**
-     * @todo Write documentation for this property.
+     * The sender of the etx.
      */
     from: null | string;
 
     /**
-     * @todo Write documentation for this property.
+     * The hash of the transaction.
      */
     hash: string;
 }
@@ -286,8 +288,10 @@ export interface TransactionReceiptParams {
 }
 
 /**
+ * A **TransactionResponseParams** encodes the minimal required properties for a formatted transaction response for
+ * either a Qi or Quai transaction.
+ *
  * @category Providers
- * @todo Write documentation for this type.
  */
 export type TransactionResponseParams = QuaiTransactionResponseParams | QiTransactionResponseParams;
 
@@ -295,7 +299,7 @@ export type TransactionResponseParams = QuaiTransactionResponseParams | QiTransa
 // Transaction Response
 
 /**
- * A **TransactionResponseParams** encodes the minimal required properties for a formatted transaction response.
+ * A **TransactionResponseParams** encodes the minimal required properties for a formatted Quai transaction response.
  *
  * @category Providers
  */
@@ -320,6 +324,9 @@ export interface QuaiTransactionResponseParams {
      */
     index: bigint;
 
+    /**
+     * The transaction type. Quai transactions are always type 0.
+     */
     type: number;
 
     /**
@@ -381,8 +388,9 @@ export interface QuaiTransactionResponseParams {
 }
 
 /**
+ * A **TransactionResponseParams** encodes the minimal required properties for a formatted Qi transaction response.
+ *
  * @category Providers
- * @todo Write documentation for this interface.
  */
 export interface QiTransactionResponseParams {
     /**
@@ -406,7 +414,7 @@ export interface QiTransactionResponseParams {
     index: bigint;
 
     /**
-     * @todo Write documentation for this property.
+     * The transaction type. Qi transactions are always type 2.
      */
     type: number;
 

--- a/src/providers/provider-jsonrpc.ts
+++ b/src/providers/provider-jsonrpc.ts
@@ -161,11 +161,9 @@ export type JsonRpcError = {
 };
 
 /**
- * When subscribing to the `"debug"` event, the {@link Listener | **Listener**} will receive this object as the first
- * parameter.
+ * When subscribing to the `"debug"` event, the Listener will receive this object as the first parameter.
  *
  * @category Providers
- * @todo Listener is no longer exported, either remove the link or rework the comment
  */
 export type DebugEventJsonRpcApiProvider =
     | {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -240,8 +240,8 @@ export interface QuaiTransactionRequest {
 
     /**
      * The [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access list. Storage slots included in the access list
-     * are //warmed// by pre-loading them, so their initial cost to fetch is guaranteed, but then each additional access
-     * is cheaper.
+     * are warmed by pre-loading them, so their initial cost to fetch is guaranteed, but then each additional access is
+     * cheaper.
      */
     accessList?: null | AccessListish;
 
@@ -356,8 +356,8 @@ export interface QuaiPreparedTransactionRequest {
 
     /**
      * The [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) access list. Storage slots included in the access list
-     * are //warmed// by pre-loading them, so their initial cost to fetch is guaranteed, but then each additional access
-     * is cheaper.
+     * are warmed by pre-loading them, so their initial cost to fetch is guaranteed, but then each additional access is
+     * cheaper.
      */
     accessList?: AccessList;
 
@@ -465,7 +465,7 @@ export function copyRequest(req: TransactionRequest): PreparedTransactionRequest
  * An Interface to indicate a {@link Block | **Block**} has been included in the blockchain. This asserts a Type Guard
  * that necessary properties are non-null.
  *
- * Before a block is included, it is a //pending// block.
+ * Before a block is included, it is a pending block.
  *
  * @category Providers
  */

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -176,12 +176,14 @@ export function addressFromTransactionRequest(tx: TransactionRequest): AddressLi
 export type TransactionRequest = QuaiTransactionRequest | QiTransactionRequest;
 
 /**
+ * A **QuaiTransactionRequest** is a Quai transaction with potentially various properties not defined, or with less
+ * strict types for its values.
+ *
  * @category Providers
- * @todo Write documentation for this interface
  */
 export interface QuaiTransactionRequest {
     /**
-     * The transaction type.
+     * The transaction type. Quai transactions are always type 0.
      */
     type?: null | number;
 
@@ -258,8 +260,10 @@ export interface QuaiTransactionRequest {
 }
 
 /**
+ * A **QiTransactionRequest** is a Qi UTXO transaction with potentially various properties not defined, or with less
+ * strict types for its values.
+ *
  * @category Providers
- * @todo Write documentation for this interface
  */
 export interface QiTransactionRequest {
     /**
@@ -292,8 +296,9 @@ export interface QiTransactionRequest {
 export type PreparedTransactionRequest = QuaiPreparedTransactionRequest | QiPreparedTransactionRequest;
 
 /**
+ * A **QuaiPreparedTransactionRequest** is a Quai transaction with potentially all properties strictly enforced.
+ *
  * @category Providers
- * @todo Write documentation for this interface
  */
 export interface QuaiPreparedTransactionRequest {
     /**
@@ -374,8 +379,9 @@ export interface QuaiPreparedTransactionRequest {
 }
 
 /**
+ * A **QiPreparedTransactionRequest** is a Qi UTXO transaction with all properties strictly enforced.
+ *
  * @category Providers
- * @todo Write documentation for this interface
  */
 export interface QiPreparedTransactionRequest {
     /**
@@ -1423,8 +1429,9 @@ export class TransactionReceipt implements TransactionReceiptParams, Iterable<Lo
 export type MinedTransactionResponse = QuaiMinedTransactionResponse | QiMinedTransactionResponse;
 
 /**
+ * A **QuaiMinedTransactionResponse** is an interface representing Quai a transaction which has been mined.
+ *
  * @category Providers
- * @todo Write documentation for this interface
  */
 export interface QuaiMinedTransactionResponse extends QuaiTransactionResponse {
     /**
@@ -1444,8 +1451,9 @@ export interface QuaiMinedTransactionResponse extends QuaiTransactionResponse {
 }
 
 /**
+ * A **QiMinedTransactionResponse** is an interface representing Qi a transaction which has been mined.
+ *
  * @category Providers
- * @todo Write documentation for this interface
  */
 export interface QiMinedTransactionResponse extends QiTransactionResponse {
     /**
@@ -1465,14 +1473,16 @@ export interface QiMinedTransactionResponse extends QiTransactionResponse {
 }
 
 /**
+ * A **TransactionResponse** is an interface representing either a Quai or Qi transaction that has been mined into a
+ * block.
+ *
  * @category Providers
- * @todo Write documentation for this interface
  */
 export type TransactionResponse = QuaiTransactionResponse | QiTransactionResponse;
 
 /**
- * A **TransactionResponse** includes all properties about a transaction that was sent to the network, which may or may
- * not be included in a block.
+ * A **QuaiTransactionResponse** includes all properties about a Quai transaction that was sent to the network, which
+ * may or may not be included in a block.
  *
  * The {@link TransactionResponse.isMined | **TransactionResponse.isMined**} can be used to check if the transaction has
  * been mined as well as type guard that the otherwise possibly `null` properties are defined.
@@ -2003,8 +2013,13 @@ export class QuaiTransactionResponse implements QuaiTransactionLike, QuaiTransac
 }
 
 /**
+ * A **QiTransactionResponse** includes all properties about a Qi transaction that was sent to the network, which may or
+ * may not be included in a block.
+ *
+ * The {@link TransactionResponse.isMined | **TransactionResponse.isMined**} can be used to check if the transaction has
+ * been mined as well as type guard that the otherwise possibly `null` properties are defined.
+ *
  * @category Providers
- * @todo Write documentation for this interface
  */
 export class QiTransactionResponse implements QiTransactionLike, QiTransactionResponseParams {
     /**

--- a/src/signers/signer.ts
+++ b/src/signers/signer.ts
@@ -21,10 +21,9 @@ export interface Signer extends Addressable, ContractRunner {
     provider: null | Provider;
 
     /**
-     * Returns a new instance of this Signer connected to //provider// or detached from any Provider if null.
+     * Returns a new instance of this Signer connected to provider or detached from any Provider if null.
      *
      * @param {null | Provider} provider - The Provider to connect to.
-     *
      * @returns {Signer} A new instance of this Signer.
      * @throws {Error} If the Signer cannot be connected to the Provider.
      */
@@ -46,7 +45,6 @@ export interface Signer extends Addressable, ContractRunner {
      *
      * @param blockTag - The blocktag to base the transaction count on, keep in mind many nodes do not honour this value
      *   and silently ignore it [default: `"latest"`]
-     *
      * @returns {Promise<number>} The next nonce.
      */
     getNonce(blockTag?: BlockTag): Promise<number>;
@@ -61,7 +59,6 @@ export interface Signer extends Addressable, ContractRunner {
      * - If `from` is specified , check that it matches this Signer
      *
      * @param {TransactionRequest} tx - The call to prepare
-     *
      * @returns {Promise<TransactionLike>} A promise resolving to the prepared transaction.
      */
     populateCall(tx: TransactionRequest): Promise<TransactionLike>;
@@ -78,7 +75,6 @@ export interface Signer extends Addressable, ContractRunner {
      *   EIP-1559, etc)
      *
      * @param {TransactionRequest} tx - The transaction to prepare.
-     *
      * @returns {Promise<TransactionLike>} A promise resolving to the prepared transaction.
      * @throws {Error} If the transaction is invalid.
      * @note Some Signer implementations may skip populating properties that
@@ -91,7 +87,7 @@ export interface Signer extends Addressable, ContractRunner {
     // Execution
 
     /**
-     * Estimates the required gas required to execute //tx// on the Blockchain. This will be the expected amount a
+     * Estimates the required gas required to execute tx on the Blockchain. This will be the expected amount a
      * transaction will require as its `gasLimit` to successfully run all the necessary computations and store the
      * needed state that the transaction intends.
      *
@@ -99,7 +95,6 @@ export interface Signer extends Addressable, ContractRunner {
      * transaction gas requirements.
      *
      * @param {TransactionRequest} tx - The transaction to estimate gas for.
-     *
      * @returns {Promise<bigint>} A promise resolving to the estimated gas.
      * @throws UNPREDICTABLE_GAS_LIMIT A transaction that is believed by the node to likely fail will throw an error
      *   during gas estimation. This could indicate that it will actually fail or that the circumstances are simply too
@@ -109,14 +104,13 @@ export interface Signer extends Addressable, ContractRunner {
     estimateGas(tx: TransactionRequest): Promise<bigint>;
 
     /**
-     * Evaluates the //tx// by running it against the current Blockchain state. This cannot change state and has no cost
-     * in ether, as it is effectively simulating execution.
+     * Evaluates th tx by running it against the current Blockchain state. This cannot change state and has no cost in
+     * ether, as it is effectively simulating execution.
      *
      * This can be used to have the Blockchain perform computations based on its state (e.g. running a Contract's
      * getters) or to simulate the effect of a transaction before actually performing an operation.
      *
      * @param {TransactionRequest} tx - The transaction to call.
-     *
      * @returns {Promise<string>} A promise resolving to the result of the call.
      */
     call(tx: TransactionRequest): Promise<string>;
@@ -129,7 +123,6 @@ export interface Signer extends Addressable, ContractRunner {
      * transaction.
      *
      * @param {TransactionRequest} tx - The transaction to sign.
-     *
      * @returns {Promise<string>} A promise resolving to the signed transaction.
      * @throws {Error} If the transaction is invalid.
      */
@@ -140,7 +133,6 @@ export interface Signer extends Addressable, ContractRunner {
      * properties for the transaction to be valid have been popualted first.
      *
      * @param {TransactionRequest} tx - The transaction to send.
-     *
      * @returns {Promise<TransactionResponse>} A promise resolving to the transaction response.
      * @throws {Error} If the transaction is invalid.
      */
@@ -155,7 +147,6 @@ export interface Signer extends Addressable, ContractRunner {
      * To sign that example as two bytes, the Uint8Array should be used (i.e. `new Uint8Array([ 0x12, 0x34 ])`).
      *
      * @param {string | Uint8Array} message - The message to sign.
-     *
      * @returns {Promise<string>} A promise resolving to the signed message.
      * @throws {Error} If the message is invalid.
      */
@@ -167,7 +158,6 @@ export interface Signer extends Addressable, ContractRunner {
      * @param {TypedDataDomain} domain - The domain of the typed data.
      * @param {Record<string, TypedDataField[]>} types - The types of the typed data.
      * @param {Record<string, any>} value - The value of the typed data.
-     *
      * @returns {Promise<string>} A promise resolving to the signed typed data.
      */
     signTypedData(

--- a/src/transaction/abstract-transaction.ts
+++ b/src/transaction/abstract-transaction.ts
@@ -34,8 +34,9 @@ export interface TransactionLike {
 }
 
 /**
+ * A **ProtoTransaction** is a JSON representation of a either a Quai or Qi transaction.
+ *
  * @category Transaction
- * @todo Write documentation for this interface.
  */
 export interface ProtoTransaction {
     /**
@@ -135,8 +136,9 @@ export interface ProtoTransaction {
 }
 
 /**
+ * A **ProtoTxOutput** is a JSON representation of a Qi UTXO transaction output.
+ *
  * @category Transaction
- * @todo Write documentation for this type.
  */
 export type ProtoTxOutput = {
     /**
@@ -151,8 +153,9 @@ export type ProtoTxOutput = {
 };
 
 /**
+ * A **ProtoTxInput** is a JSON representation of a Qi UTXO transaction input.
+ *
  * @category Transaction
- * @todo Write documentation for this type.
  */
 export type ProtoTxInput = {
     /**
@@ -177,8 +180,9 @@ export type ProtoTxInput = {
 };
 
 /**
+ * A **ProtoAccessList** is a JSON representation of an access list.
+ *
  * @category Transaction
- * @todo Write documentation for this interface.
  */
 export interface ProtoAccessList {
     /**
@@ -188,8 +192,9 @@ export interface ProtoAccessList {
 }
 
 /**
+ * A **ProtoAccessTuple** is a JSON representation of an access tuple.
+ *
  * @category Transaction
- * @todo Write documentation for this interface.
  */
 export interface ProtoAccessTuple {
     /**
@@ -206,9 +211,8 @@ export interface ProtoAccessTuple {
 type allowedSignatureTypes = Signature | string;
 
 /**
- * An **AbstractTransaction** describes the common operations to be executed on Quai and Qi ledgers
- * by an Externally Owned Account (EOA). This class must be subclassed by concrete implementations
- * of transactions on each ledger.
+ * An **AbstractTransaction** describes the common operations to be executed on Quai and Qi ledgers by an Externally
+ * Owned Account (EOA). This class must be subclassed by concrete implementations of transactions on each ledger.
  */
 export abstract class AbstractTransaction<S extends allowedSignatureTypes> implements TransactionLike {
     protected _type: number | null;

--- a/src/transaction/quai-transaction.ts
+++ b/src/transaction/quai-transaction.ts
@@ -21,8 +21,9 @@ import { ProtoTransaction } from './abstract-transaction.js';
 import { Zone } from '../constants/index.js';
 
 /**
+ * A **QuaiTransactionLike** is a JSON representation of a Quai transaction.
+ *
  * @category Transaction
- * @todo Write documentation for this interface.
  */
 export interface QuaiTransactionLike extends TransactionLike {
     /**
@@ -104,7 +105,6 @@ export function _parseSignature(fields: Array<string>): Signature {
  * Represents a Quai transaction.
  *
  * @category Transaction
- * @todo Write documentation for this class.
  */
 export class QuaiTransaction extends AbstractTransaction<Signature> implements QuaiTransactionLike {
     #to: null | string;

--- a/src/transaction/utxo.ts
+++ b/src/transaction/utxo.ts
@@ -4,9 +4,9 @@ import type { BigNumberish } from '../utils/index.js';
 
 /**
  * Represents an a spendable transaction outpoint.
+ *
+ * @ignore
  * @category Transaction
- * @todo Write documentation for this type.
- * @todo If not used, replace with `ignore`
  */
 export type Outpoint = {
     txhash: string;
@@ -16,8 +16,9 @@ export type Outpoint = {
 
 /**
  * Represents a UTXO entry.
- * @category Transaction
+ *
  * @ignore
+ * @category Transaction
  */
 export interface UTXOEntry {
     denomination: null | bigint;
@@ -26,8 +27,9 @@ export interface UTXOEntry {
 
 /**
  * Represents a UTXO-like object.
- * @category Transaction
+ *
  * @ignore
+ * @category Transaction
  */
 export interface UTXOLike extends UTXOEntry {
     txhash?: null | string;
@@ -36,6 +38,7 @@ export interface UTXOLike extends UTXOEntry {
 
 /**
  * Represents a Qi transaction input.
+ *
  * @category Transaction
  */
 export type TxInput = {
@@ -46,6 +49,7 @@ export type TxInput = {
 
 /**
  * Represents a Qi transaction output.
+ *
  * @category Transaction
  */
 export type TxOutput = {
@@ -55,6 +59,7 @@ export type TxOutput = {
 
 /**
  * List of supported Qi denominations.
+ *
  * @category Transaction
  */
 export const denominations: bigint[] = [
@@ -79,6 +84,7 @@ export const denominations: bigint[] = [
 
 /**
  * Checks if the provided denomination is valid.
+ *
  * @category Transaction
  * @param {bigint} denomination - The denomination to check.
  * @returns {boolean} True if the denomination is valid, false otherwise.
@@ -89,11 +95,12 @@ function isValidDenomination(denomination: bigint): boolean {
 
 /**
  * Handles conversion of string to bigint, specifically for transaction parameters.
+ *
+ * @ignore
  * @category Transaction
  * @param {string} value - The value to convert.
  * @param {string} param - The parameter name.
  * @returns {bigint} The converted value.
- * @ignore
  */
 function handleBigInt(value: string, param: string): bigint {
     if (value === '0x') {
@@ -104,6 +111,7 @@ function handleBigInt(value: string, param: string): bigint {
 
 /**
  * Given a value, returns an array of supported denominations that sum to the value.
+ *
  * @category Transaction
  * @param {bigint} value - The value to denominate.
  * @returns {bigint[]} An array of denominations that sum to the value.
@@ -137,6 +145,7 @@ export function denominate(value: bigint): bigint[] {
 
 /**
  * Represents a UTXO (Unspent Transaction Output).
+ *
  * @category Transaction
  * @implements {UTXOLike}
  */
@@ -148,6 +157,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Gets the transaction hash.
+     *
      * @returns {null | string} The transaction hash.
      */
     get txhash(): null | string {
@@ -156,6 +166,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Sets the transaction hash.
+     *
      * @param {null | string} value - The transaction hash.
      */
     set txhash(value: null | string) {
@@ -164,6 +175,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Gets the index.
+     *
      * @returns {null | number} The index.
      */
     get index(): null | number {
@@ -172,6 +184,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Sets the index.
+     *
      * @param {null | number} value - The index.
      */
     set index(value: null | number) {
@@ -180,6 +193,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Gets the address.
+     *
      * @returns {string} The address.
      */
     get address(): string {
@@ -188,6 +202,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Sets the address.
+     *
      * @param {string} value - The address.
      * @throws {Error} If the address is invalid.
      */
@@ -198,6 +213,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Gets the denomination.
+     *
      * @returns {null | bigint} The denomination.
      */
     get denomination(): null | bigint {
@@ -206,6 +222,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Sets the denomination.
+     *
      * @param {null | BigNumberish} value - The denomination.
      * @throws {Error} If the denomination value is invalid.
      */
@@ -235,6 +252,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Converts the UTXO instance to a JSON object.
+     *
      * @returns {any} A JSON representation of the UTXO instance.
      */
     toJSON(): any {
@@ -248,6 +266,7 @@ export class UTXO implements UTXOLike {
 
     /**
      * Creates a UTXO instance from a UTXOLike object.
+     *
      * @param {UTXOLike} utxo - The UTXOLike object to convert.
      * @returns {UTXO} The UTXO instance.
      */

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -102,8 +102,6 @@ function stringify(value: any): any {
  *
  * **`"UNEXPECTED_ARGUMENT"`** - see {@link UnexpectedArgumentError | **UnexpectedArgumentError**}
  *
- * **`"VALUE_MISMATCH"`** - //unused//
- *
  * **Blockchain Errors**
  *
  * **`"CALL_EXCEPTION"`** - see {@link CallExceptionError | **CallExceptionError**}

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -66,11 +66,10 @@ export interface EventEmitterable<T> {
 }
 
 /**
- * When an {@link EventEmitterable | **EventEmitterable**} triggers a [[Listener]], the callback always ahas one
- * additional argument passed, which is an **EventPayload**.
+ * When an {@link EventEmitterable | **EventEmitterable**} triggers a Listener, the callback always ahas one additional
+ * argument passed, which is an **EventPayload**.
  *
  * @category Utils
- * @todo Listener is no longer exported, need to revise comment or remove link
  */
 export class EventPayload<T> {
     /**

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -213,7 +213,6 @@ function checkSignal(signal?: FetchCancelSignal): FetchCancelSignal {
  * req = new FetchRequest('https://www.ricmoo.com');
  * resp = await req.send();
  * resp.body.length;
- * //_result:
  * ```
  */
 export class FetchRequest implements Iterable<[key: string, value: string]> {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -121,7 +121,6 @@ async function dataGatewayFunc(url: string, signal?: FetchCancelSignal): Promise
  *
  * @category Utils
  * @param {string} baseUrl - The base URL of the IPFS gateway.
- *
  * @returns {FetchGatewayFunc} The gateway function.
  */
 function getIpfsGatewayFunc(baseUrl: string): FetchGatewayFunc {
@@ -251,7 +250,7 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
     }
 
     /**
-     * The fetch body, if any, to send as the request body. //(default: null)//
+     * The fetch body, if any, to send as the request body. (default: null)
      *
      * When setting a body, the intrinsic `Content-Type` is automatically set and will be used if **not overridden** by
      * setting a custom header.
@@ -347,7 +346,6 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
      * Get the header for `key`, ignoring case.
      *
      * @param {string} key - The header key to retrieve.
-     *
      * @returns {string} The header value.
      */
     getHeader(key: string): string {
@@ -411,7 +409,7 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
     }
 
     /**
-     * Enable and request gzip-encoded responses. The response will automatically be decompressed. //(default: true)//
+     * Enable and request gzip-encoded responses. The response will automatically be decompressed. (default: true)
      */
     get allowGzip(): boolean {
         return this.#gzip;
@@ -421,7 +419,7 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
     }
 
     /**
-     * Allow `Authentication` credentials to be sent over insecure channels. //(default: false)//
+     * Allow `Authentication` credentials to be sent over insecure channels. (default: false)
      */
     get allowInsecureAuthentication(): boolean {
         return !!this.#allowInsecure;
@@ -431,7 +429,7 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
     }
 
     /**
-     * The timeout (in milliseconds) to wait for a complete response. //(default: 5 minutes)//
+     * The timeout (in milliseconds) to wait for a complete response. (default: 5 minutes)
      */
     get timeout(): number {
         return this.#timeout;
@@ -671,7 +669,6 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
      * Returns a new {@link FetchRequest | **FetchRequest**} that represents the redirection to `location`.
      *
      * @param {string} location - The location to redirect to.
-     *
      * @returns {FetchRequest} The new request.
      */
     redirect(location: string): FetchRequest {
@@ -757,7 +754,6 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
      * Get the current Gateway function for `scheme`.
      *
      * @param {string} scheme - The scheme to get the gateway for.
-     *
      * @returns {FetchGatewayFunc | null} The gateway function, or null if not found.
      */
     static getGateway(scheme: string): null | FetchGatewayFunc {
@@ -812,7 +808,6 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
      * fetching HTTP content.
      *
      * @param {Record<string, any>} [options] - The options to use when creating the getUrl function.
-     *
      * @returns {FetchGetUrlFunc} The getUrl function.
      * @throws {Error} If the gateways are locked.
      */
@@ -840,7 +835,6 @@ export class FetchRequest implements Iterable<[key: string, value: string]> {
      * The default IPFS gateway used internally is `"https:/\/gateway.ipfs.io/ipfs/"`.
      *
      * @param {string} baseUrl - The base URL of the IPFS gateway.
-     *
      * @returns {FetchGatewayFunc} The gateway function.
      */
     static createIpfsGatewayFunc(baseUrl: string): FetchGatewayFunc {
@@ -977,7 +971,6 @@ export class FetchResponse implements Iterable<[key: string, value: string]> {
      *
      * @param {string} [message] - The error message to use.
      * @param {Error} [error] - The error to use.
-     *
      * @returns {FetchResponse} The error response.
      */
     makeServerError(message?: string, error?: Error): FetchResponse {
@@ -1019,7 +1012,6 @@ export class FetchResponse implements Iterable<[key: string, value: string]> {
      * Get the header value for `key`, ignoring case.
      *
      * @param {string} key - The header key to retrieve.
-     *
      * @returns {string} The header value.
      */
     getHeader(key: string): string {

--- a/src/utils/fixednumber.ts
+++ b/src/utils/fixednumber.ts
@@ -202,24 +202,24 @@ function toString(val: bigint, decimals: number) {
  * 10 raised to the power of `decimals`.
  *
  * If operations are performed that cause a value to grow too high (close to positive infinity) or too low (close to
- * negative infinity), the value is said to //overflow//.
+ * negative infinity), the value is said to overflow.
  *
  * For example, an 8-bit signed value, with 0 decimals may only be within the range `-128` to `127`; so `-128 - 1` will
  * overflow and become `127`. Likewise, `127 + 1` will overflow and become `-127`.
  *
- * Many operation have a normal and //unsafe// variant. The normal variant will throw a
- * [NumericFaultError](../interfaces/NumericFaultError) on any overflow, while the //unsafe// variant will silently
- * allow overflow, corrupting its value value.
+ * Many operation have a normal and unsafe variant. The normal variant will throw a
+ * [NumericFaultError](../interfaces/NumericFaultError) on any overflow, while the unsafe variant will silently allow
+ * overflow, corrupting its value value.
  *
  * If operations are performed that cause a value to become too small (close to zero), the value loses precison and is
- * said to //underflow//.
+ * said to underflow.
  *
  * For example, an value with 1 decimal place may store a number as small as `0.1`, but the value of `0.1 / 2` is
  * `0.05`, which cannot fit into 1 decimal place, so underflow occurs which means precision is lost and the value
  * becomes `0`.
  *
- * Some operations have a normal and //signalling// variant. The normal variant will silently ignore underflow, while
- * the //signalling// variant will thow a [NumericFaultError](../interfaces/NumericFaultError) on underflow.
+ * Some operations have a normal and signalling variant. The normal variant will silently ignore underflow, while the
+ * signalling variant will thow a [NumericFaultError](../interfaces/NumericFaultError) on underflow.
  *
  * @category Utils
  */
@@ -246,7 +246,7 @@ export class FixedNumber {
 
     // Use this when changing this file to get some typing info,
     // but then switch to any to mask the internal type
-    //constructor(guard: any, value: bigint, format: _FixedFormat) {
+    // constructor(guard: any, value: bigint, format: _FixedFormat) {
 
     /**
      * @ignore
@@ -311,7 +311,6 @@ export class FixedNumber {
      * Returns a new {@link FixedNumber | **FixedNumber**} with the result of `this` added to `other`, ignoring overflow.
      *
      * @param {FixedNumber} other - The value to add to `this`.
-     *
      * @returns {FixedNumber} The result of the addition.
      */
     addUnsafe(other: FixedNumber): FixedNumber {
@@ -323,7 +322,6 @@ export class FixedNumber {
      * [NumericFaultError](../interfaces/NumericFaultError) is thrown if overflow occurs.
      *
      * @param {FixedNumber} other - The value to add to `this`.
-     *
      * @returns {FixedNumber} The result of the addition.
      */
     add(other: FixedNumber): FixedNumber {
@@ -340,7 +338,6 @@ export class FixedNumber {
      * overflow.
      *
      * @param {FixedNumber} other - The value to subtract from `this`.
-     *
      * @returns {FixedNumber} The result of the subtraction.
      */
     subUnsafe(other: FixedNumber): FixedNumber {
@@ -352,7 +349,6 @@ export class FixedNumber {
      * [NumericFaultError](../interfaces/NumericFaultError) is thrown if overflow occurs.
      *
      * @param {FixedNumber} other - The value to subtract from `this`.
-     *
      * @returns {FixedNumber} The result of the subtraction.
      */
     sub(other: FixedNumber): FixedNumber {
@@ -369,7 +365,6 @@ export class FixedNumber {
      * overflow and underflow (precision loss).
      *
      * @param {FixedNumber} other - The value to multiply `this` by.
-     *
      * @returns {FixedNumber} The result of the multiplication.
      */
     mulUnsafe(other: FixedNumber): FixedNumber {
@@ -381,7 +376,6 @@ export class FixedNumber {
      * [NumericFaultError](../interfaces/NumericFaultError) is thrown if overflow occurs.
      *
      * @param {FixedNumber} other - The value to multiply `this` by.
-     *
      * @returns {FixedNumber} The result of the multiplication.
      */
     mul(other: FixedNumber): FixedNumber {
@@ -394,7 +388,6 @@ export class FixedNumber {
      * loss) occurs.
      *
      * @param {FixedNumber} other - The value to multiply `this` by.
-     *
      * @returns {FixedNumber} The result of the multiplication.
      * @throws {NumericFaultError} Thrown if overflow or underflow occurs.
      * @throws {NumericFaultError} Thrown if division by 0 occurs.
@@ -425,7 +418,6 @@ export class FixedNumber {
      * underflow (precision loss). A [NumericFaultError](../interfaces/NumericFaultError) is thrown if overflow occurs.
      *
      * @param {FixedNumber} other - The value to divide `this` by.
-     *
      * @returns {FixedNumber} The result of the division.
      */
     divUnsafe(other: FixedNumber): FixedNumber {
@@ -437,7 +429,6 @@ export class FixedNumber {
      * underflow (precision loss). A [NumericFaultError](../interfaces/NumericFaultError) is thrown if overflow occurs.
      *
      * @param {FixedNumber} other - The value to divide `this` by.
-     *
      * @returns {FixedNumber} The result of the division.
      */
     div(other: FixedNumber): FixedNumber {
@@ -449,7 +440,6 @@ export class FixedNumber {
      * [NumericFaultError](../interfaces/NumericFaultError) is thrown if underflow (precision loss) occurs.
      *
      * @param {FixedNumber} other - The value to divide `this` by.
-     *
      * @returns {FixedNumber} The result of the division.
      * @throws {NumericFaultError} Thrown if underflow occurs.
      */
@@ -476,7 +466,6 @@ export class FixedNumber {
      * implies both are equal.
      *
      * @param {FixedNumber} other - The value to compare to `this`.
-     *
      * @returns {number} The comparison result.
      */
     cmp(other: FixedNumber): number {
@@ -505,7 +494,6 @@ export class FixedNumber {
      * Returns true if `other` is equal to `this`.
      *
      * @param {FixedNumber} other - The value to compare to `this`.
-     *
      * @returns {boolean} True if `other` is equal to `this`.
      */
     eq(other: FixedNumber): boolean {
@@ -516,7 +504,6 @@ export class FixedNumber {
      * Returns true if `other` is less than to `this`.
      *
      * @param {FixedNumber} other - The value to compare to `this`.
-     *
      * @returns {boolean} True if `other` is less than to `this`.
      */
     lt(other: FixedNumber): boolean {
@@ -527,7 +514,6 @@ export class FixedNumber {
      * Returns true if `other` is less than or equal to `this`.
      *
      * @param {FixedNumber} other - The value to compare to `this`.
-     *
      * @returns {boolean} True if `other` is less than or equal to `this`.
      */
     lte(other: FixedNumber): boolean {
@@ -538,7 +524,6 @@ export class FixedNumber {
      * Returns true if `other` is greater than to `this`.
      *
      * @param {FixedNumber} other - The value to compare to `this`.
-     *
      * @returns {boolean} True if `other` is greater than to `this`.
      */
     gt(other: FixedNumber): boolean {
@@ -549,7 +534,6 @@ export class FixedNumber {
      * Returns true if `other` is greater than or equal to `this`.
      *
      * @param {FixedNumber} other - The value to compare to `this`.
-     *
      * @returns {boolean} True if `other` is greater than or equal to `this`.
      */
     gte(other: FixedNumber): boolean {
@@ -595,7 +579,6 @@ export class FixedNumber {
      * places.
      *
      * @param {number} [decimals] - The number of decimal places to round to.
-     *
      * @returns {FixedNumber} The rounded value.
      */
     round(decimals?: number): FixedNumber {
@@ -679,7 +662,6 @@ export class FixedNumber {
      * @param {BigNumberish} _value - The value to create a FixedNumber for.
      * @param {Numeric} [_decimals] - The number of decimal places in `value`.
      * @param {FixedFormat} [_format] - The format for the FixedNumber.
-     *
      * @returns {FixedNumber} The FixedNumber for `value`.
      */
     static fromValue(_value: BigNumberish, _decimals?: Numeric, _format?: FixedFormat): FixedNumber {
@@ -713,7 +695,6 @@ export class FixedNumber {
      *
      * @param {BigNumberish} _value - The value to create a FixedNumber for.
      * @param {FixedFormat} [_format] - The format for the FixedNumber.
-     *
      * @returns {FixedNumber} The FixedNumber for `value`.
      */
     static fromString(_value: string, _format?: FixedFormat): FixedNumber {
@@ -760,7 +741,6 @@ export class FixedNumber {
      *
      * @param {BytesLike} _value - The big-endian representation of the value.
      * @param {FixedFormat} [_format] - The format for the FixedNumber.
-     *
      * @returns {FixedNumber} The FixedNumber for `value`.
      */
     static fromBytes(_value: BytesLike, _format?: FixedFormat): FixedNumber {

--- a/src/utils/fixednumber.ts
+++ b/src/utils/fixednumber.ts
@@ -34,25 +34,6 @@ function getTens(decimals: number): bigint {
 }
 
 /**
- * A description of a fixed-point arithmetic field.
- *
- * When specifying the fixed format, the values override the default of a `fixed128x18`, which implies a signed 128-bit
- * value with 18 decimals of precision.
- *
- * The alias `fixed` and `ufixed` can be used for `fixed128x18` and `ufixed128x18` respectively.
- *
- * When a fixed format string begins with a `u`, it indicates the field is unsigned, so any negative values will
- * overflow. The first number indicates the bit-width and the second number indicates the decimal precision.
- *
- * When a `number` is used for a fixed format, it indicates the number of decimal places, and the default width and
- * signed-ness will be used.
- *
- * The bit-width must be byte aligned and the decimals can be at most 80.
- *
- * @todo This comment is seemingly unused, remove if not needed
- */
-
-/**
  * Returns a new FixedFormat for `value`.
  *
  * If `value` is specified as a `number`, the bit-width is 128 bits and `value` is used for the `decimals`.

--- a/src/utils/maths.ts
+++ b/src/utils/maths.ts
@@ -36,7 +36,6 @@ const maxValue = 0x1fffffffffffff;
  * @category Utils
  * @param {BigNumberish} _value - The value to convert.
  * @param {Numeric} _width - The width of the value in bits.
- *
  * @returns {bigint} The value.
  * @throws {Error} If the value is too large for the width.
  */
@@ -67,7 +66,6 @@ export function fromTwos(_value: BigNumberish, _width: Numeric): bigint {
  * @category Utils
  * @param {BigNumberish} _value - The value to convert.
  * @param {Numeric} _width - The width of the value in bits.
- *
  * @returns {bigint} The value.
  * @throws {Error} If the value is too large for the width.
  */
@@ -103,7 +101,6 @@ export function toTwos(_value: BigNumberish, _width: Numeric): bigint {
  * @category Utils
  * @param {BigNumberish} _value - The value to mask.
  * @param {Numeric} _bits - The number of bits to mask.
- *
  * @returns {bigint} The masked value.
  */
 export function mask(_value: BigNumberish, _bits: Numeric): bigint {
@@ -118,7 +115,6 @@ export function mask(_value: BigNumberish, _bits: Numeric): bigint {
  * @category Utils
  * @param {BigNumberish} value - The value to convert.
  * @param {string} name - The name of the value.
- *
  * @returns {bigint} The value.
  */
 export function getBigInt(value: BigNumberish, name?: string): bigint {
@@ -150,7 +146,6 @@ export function getBigInt(value: BigNumberish, name?: string): bigint {
  *
  * @category Utils
  * @param {BigNumberish} value - The value to convert.
- *
  * @returns {bigint} The absolute value.
  */
 export function bigIntAbs(value: BigNumberish): bigint {
@@ -169,7 +164,6 @@ export function bigIntAbs(value: BigNumberish): bigint {
  * @category Utils
  * @param {BigNumberish} value - The value to convert.
  * @param {string} name - The name of the value.
- *
  * @returns {bigint} The value.
  * @throws {Error} If the value is negative.
  */
@@ -190,7 +184,6 @@ const Nibbles = '0123456789abcdef';
  *
  * @category Utils
  * @param {BigNumberish | Uint8Array} value - The value to convert.
- *
  * @returns {bigint} The value.
  */
 export function toBigInt(value: BigNumberish | Uint8Array): bigint {
@@ -207,13 +200,11 @@ export function toBigInt(value: BigNumberish | Uint8Array): bigint {
 }
 
 /**
- * Gets a //number// from `value`. If it is an invalid value for a //number//, then an ArgumentError will be thrown for
- * `name`.
+ * Gets a number from `value`. If it is an invalid value for a number, then an ArgumentError will be thrown for `name`.
  *
  * @category Utils
  * @param {BigNumberish} value - The value to convert.
  * @param {string} name - The name of the value.
- *
  * @returns {number} The value.
  * @throws {Error} If the value is invalid.
  * @throws {Error} If the value is too large.
@@ -246,7 +237,6 @@ export function getNumber(value: BigNumberish, name?: string): number {
  *
  * @category Utils
  * @param {BigNumberish | Uint8Array} value - The value to convert.
- *
  * @returns {number} The value.
  * @throws {Error} If the value is not safe to convert to a number.
  */
@@ -260,7 +250,6 @@ export function toNumber(value: BigNumberish | Uint8Array): number {
  * @category Utils
  * @param {BigNumberish} _value - The value to convert.
  * @param {Numeric} _width - The width of the value in bytes.
- *
  * @returns {string} The hexstring.
  * @throws {Error} If the value exceeds the width.
  */
@@ -296,7 +285,6 @@ export function toBeHex(_value: BigNumberish, _width?: Numeric): string {
  *
  * @category Utils
  * @param {BigNumberish} _value - The value to convert.
- *
  * @returns {Uint8Array} The value.
  */
 export function toBeArray(_value: BigNumberish): Uint8Array {
@@ -321,14 +309,13 @@ export function toBeArray(_value: BigNumberish): Uint8Array {
 }
 
 /**
- * Returns a `HexString` for `value` safe to use as a //Quantity//.
+ * Returns a `HexString` for `value` safe to use as a Quantity.
  *
- * A //Quantity// does not have and leading 0 values unless the value is the literal value `0x0`. This is most commonly
- * used for JSSON-RPC numeric values.
+ * A Quantity does not have and leading 0 values unless the value is the literal value `0x0`. This is most commonly used
+ * for JSSON-RPC numeric values.
  *
  * @category Utils
  * @param {BigNumberish | Uint8Array} value - The value to convert.
- *
  * @returns {string} The quantity.
  */
 export function toQuantity(value: BytesLike | BigNumberish): string {

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -10,8 +10,7 @@
  * This creates a clear distinction, between values to be used by code (integers) and values used for display logic to
  * users (decimals).
  *
- * The native unit in Ethereum, //ether// is divisible to 18 decimal places, where each individual unit is called a
- * //wei//.
+ * The native unit in Ethereum, ether is divisible to 18 decimal places, where each individual unit is called a wei.
  */
 import { assertArgument } from './errors.js';
 import { FixedNumber } from './fixednumber.js';
@@ -22,7 +21,7 @@ import type { BigNumberish, Numeric } from './index.js';
 const names = ['wei', 'kwei', 'mwei', 'gwei', 'szabo', 'finney', 'ether'];
 
 /**
- * Converts `value` into a //decimal string//, assuming `unit` decimal places. The `unit` may be the number of decimal
+ * Converts `value` into a decimal string, assuming `unit` decimal places. The `unit` may be the number of decimal
  * places or the name of a unit (e.g. `"gwei"` for 9 decimal places).
  *
  * @category Utils
@@ -45,8 +44,8 @@ export function formatUnits(value: BigNumberish, unit?: string | Numeric): strin
 }
 
 /**
- * Converts the //decimal string// `value` to a BigInt, assuming `unit` decimal places. The `unit` may the number of
- * decimal places or the name of a unit (e.g. `"gwei"` for 9 decimal places).
+ * Converts the decimal string `value` to a BigInt, assuming `unit` decimal places. The `unit` may the number of decimal
+ * places or the name of a unit (e.g. `"gwei"` for 9 decimal places).
  *
  * @category Utils
  * @param {string} value - The value to convert.
@@ -71,7 +70,7 @@ export function parseUnits(value: string, unit?: string | Numeric): bigint {
 }
 
 /**
- * Converts `value` into a //decimal string// using 18 decimal places.
+ * Converts `value` into a decimal string sing 18 decimal places.
  *
  * @category Utils
  * @param {BigNumberish} wei - The value to convert.
@@ -82,7 +81,7 @@ export function formatQuai(wei: BigNumberish): string {
 }
 
 /**
- * Converts `value` into a //decimal string// using 3 decimal places.
+ * Converts `value` into a decimal string using 3 decimal places.
  *
  * @category Utils
  * @param {BigNumberish} value - The value to convert.
@@ -93,7 +92,7 @@ export function formatQi(value: BigNumberish): string {
 }
 
 /**
- * Converts the //decimal string// `quai` to a BigInt, using 18 decimal places.
+ * Converts the decimal string `quai` to a BigInt, using 18 decimal places.
  *
  * @category Utils
  * @param {string} ether - The value to convert.
@@ -104,7 +103,7 @@ export function parseQuai(ether: string): bigint {
 }
 
 /**
- * Converts `value` into a //decimal string// using 3 decimal places.
+ * Converts `value` into a decimal string using 3 decimal places.
  *
  * @category Utils
  * @param {string} value - The value to convert.

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -1,8 +1,8 @@
 /**
  * When interacting with Ethereum, it is necessary to use a private key authenticate actions by signing a payload.
  *
- * Wallets are the simplest way to expose the concept of an //Externally Owner Account// (EOA) as it wraps a private key
- * and supports high-level methods to sign common types of interaction and send transactions.
+ * Wallets are the simplest way to expose the concept of an Externally Owner Account (EOA) as it wraps a private key and
+ * supports high-level methods to sign common types of interaction and send transactions.
  *
  * The class most developers will want to use is [Wallet](../classes/Wallet), which can load a private key directly or
  * from any common wallet format.


### PR DESCRIPTION
- Remove old flatworm example refs
  - `_result:`
  - `_error:`
- Remove all @todo tags in jsdoc, they were appearing in the docs
- Remove old flatworm `//` markdown syntax as it was appearing in the docs