### PR TITLE
IMP-145 - New error handlers

### DIFF
--- a/src/providers/provider-jsonrpc.ts
+++ b/src/providers/provider-jsonrpc.ts
@@ -1344,6 +1344,10 @@ export abstract class JsonRpcApiProvider<C = FetchRequest> extends AbstractProvi
                     info: { transaction, info: { error } },
                 });
             }
+
+            if (message.match(/already known/i)) {
+                return makeError('transaction already known', 'TRANSACTION_ALREADY_KNOWN', { info: { error } });
+            }
         }
 
         let unsupported = !!message.match(/the method .* does not exist/i);

--- a/src/providers/provider-jsonrpc.ts
+++ b/src/providers/provider-jsonrpc.ts
@@ -1291,6 +1291,10 @@ export abstract class JsonRpcApiProvider<C = FetchRequest> extends AbstractProvi
 
         const message = JSON.stringify(spelunkMessage(error));
 
+        if (method === 'quai_getTransactionByHash' && error.message && error.message.match(/transaction not found/i)) {
+            return makeError('transaction not found', 'TRANSACTION_NOT_FOUND', { info: { payload, error } });
+        }
+
         if (typeof error.message === 'string' && error.message.match(/user denied|quais-user-denied/i)) {
             const actionMap: Record<
                 string,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -149,6 +149,7 @@ export type ErrorCode =
     | 'TRANSACTION_REPLACED'
     | 'UNCONFIGURED_NAME'
     | 'OFFCHAIN_FAULT'
+    | 'TRANSACTION_NOT_FOUND'
 
     // User Interaction
     | 'ACTION_REJECTED';
@@ -566,6 +567,13 @@ export interface ActionRejectedError extends quaisError<'ACTION_REJECTED'> {
     reason: 'expired' | 'rejected' | 'pending';
 }
 
+/**
+ * This Error indicates the requested transaction was not found by the node.
+ *
+ * @category Utils
+ */
+export interface TransactionNotFoundError extends quaisError<'TRANSACTION_NOT_FOUND'> {}
+
 // Coding; converts an ErrorCode its Typed Error
 
 /**
@@ -611,7 +619,9 @@ export type CodedquaisError<T> = T extends 'UNKNOWN_ERROR'
                                       ? TransactionReplacedError
                                       : T extends 'ACTION_REJECTED'
                                         ? ActionRejectedError
-                                        : never;
+                                        : T extends 'TRANSACTION_NOT_FOUND'
+                                          ? TransactionNotFoundError
+                                          : never;
 
 /**
  * Returns true if the `error` matches an error thrown by quais that matches the error `code`.

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -150,6 +150,7 @@ export type ErrorCode =
     | 'UNCONFIGURED_NAME'
     | 'OFFCHAIN_FAULT'
     | 'TRANSACTION_NOT_FOUND'
+    | 'TRANSACTION_ALREADY_KNOWN'
 
     // User Interaction
     | 'ACTION_REJECTED';
@@ -574,6 +575,13 @@ export interface ActionRejectedError extends quaisError<'ACTION_REJECTED'> {
  */
 export interface TransactionNotFoundError extends quaisError<'TRANSACTION_NOT_FOUND'> {}
 
+/**
+ * This Error indicates the sent transaction is already known to the node.
+ *
+ * @category Utils
+ */
+export interface TransactionAlreadyKnown extends quaisError<'TRANSACTION_ALREADY_KNOWN'> {}
+
 // Coding; converts an ErrorCode its Typed Error
 
 /**
@@ -621,7 +629,9 @@ export type CodedquaisError<T> = T extends 'UNKNOWN_ERROR'
                                         ? ActionRejectedError
                                         : T extends 'TRANSACTION_NOT_FOUND'
                                           ? TransactionNotFoundError
-                                          : never;
+                                          : T extends 'TRANSACTION_ALREADY_KNOWN'
+                                            ? TransactionAlreadyKnown
+                                            : never;
 
 /**
  * Returns true if the `error` matches an error thrown by quais that matches the error `code`.


### PR DESCRIPTION
Add error handlers for RPC response errors:

- `already known`

- `transaction not found`