### PR TITLE
Browser provider hang fix

### DIFF
--- a/src/providers/provider-browser.ts
+++ b/src/providers/provider-browser.ts
@@ -70,6 +70,8 @@ export class BrowserProvider extends JsonRpcApiProvider {
     constructor(ethereum: Eip1193Provider, network?: Networkish) {
         super(network, { batchMaxCount: 1 });
 
+        if (this.initResolvePromise) this.initResolvePromise();
+
         this.#request = async (method: string, params: Array<any> | Record<string, any>) => {
             const payload = { method, params };
             this.emit('debug', undefined, { action: 'sendEip1193Request', payload });
@@ -116,6 +118,7 @@ export class BrowserProvider extends JsonRpcApiProvider {
      * @returns {Promise<any>} The result of the request.
      */
     async send(method: string, params: Array<any> | Record<string, any>): Promise<any> {
+        console.log('BrowserProvider.send', method, params);
         await this._start();
 
         return await super.send(method, params);

--- a/src/providers/provider-jsonrpc.ts
+++ b/src/providers/provider-jsonrpc.ts
@@ -157,6 +157,7 @@ export type JsonRpcError = {
         code: number;
         message?: string;
         data?: any;
+        shard?: Shard;
     };
 };
 


### PR DESCRIPTION
Fixes bug that prevented `BrowserProvider.initPromise` from ever resolving and as a result blocking any requests. This also adds support for requests that are shard specific.