### PR TITLE
Fix invalid Qi transaction signatures

### DIFF
--- a/src/transaction/utxo.ts
+++ b/src/transaction/utxo.ts
@@ -148,6 +148,7 @@ export class UTXO implements UTXOLike {
     #index: null | number;
     #address: null | string;
     #denomination: null | number;
+    #lock: null | number;
 
     /**
      * Gets the transaction hash.
@@ -233,6 +234,14 @@ export class UTXO implements UTXOLike {
         this.#denomination = value;
     }
 
+    get lock(): null | number {
+        return this.#lock;
+    }
+
+    set lock(value: null | number) {
+        this.#lock = value;
+    }
+
     /**
      * Constructs a new UTXO instance with null properties.
      */
@@ -241,6 +250,7 @@ export class UTXO implements UTXOLike {
         this.#index = null;
         this.#address = null;
         this.#denomination = null;
+        this.#lock = null;
     }
 
     /**


### PR DESCRIPTION
- Properly handle musig signature creation when multiple inputs share a signing key
- Add `getSpendableBalance` and `getLockedBalance` to `QiHDWallet`