### PR TITLE
Remove access list from static call

### DIFF
--- a/src/providers/abstract-provider.ts
+++ b/src/providers/abstract-provider.ts
@@ -1549,11 +1549,6 @@ export class AbstractProvider<C = FetchRequest> implements Provider {
             blockTag: this._getBlockTag(shard, _tx.blockTag),
         });
 
-        tx.accessList = (await this.createAccessList(tx)).map((it) => {
-            it.address = formatMixedCaseChecksumAddress(it.address);
-            return it;
-        });
-
         return await this.#checkNetwork(this.#call(tx, blockTag, -1, zone), shard);
     }
 


### PR DESCRIPTION
- Remove accessList creation from static call method in provider
- Was causing issues when calling read-only methods on contracts