### PR TITLE
Update examples provider syntax

### DIFF
--- a/examples/providers/get-address-data.js
+++ b/examples/providers/get-address-data.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Get balance of a Quai or Qi address
     const balance = await provider.getBalance('0x002F4783248e2D6FF1aa6482A8C0D7a76de3C329', 'latest');

--- a/examples/providers/get-chain-data.js
+++ b/examples/providers/get-chain-data.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Get block (with includeTransactions set to false)
     const block = await provider.getBlock(quais.Shard.Cyprus1, 'latest', false);

--- a/examples/providers/query-event.js
+++ b/examples/providers/query-event.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Define simplified abi
     const abi = ['event Transfer(address indexed from, address indexed to, uint amount)'];

--- a/examples/providers/query-logs.js
+++ b/examples/providers/query-logs.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Define filter for any Transfer events in the last 10 blocks in Cyprus1 ([0, 0])
     const filter = {

--- a/examples/providers/ws-subscribe-block.js
+++ b/examples/providers/ws-subscribe-block.js
@@ -2,7 +2,7 @@ const quais = require('../../lib/commonjs/quais');
 require('dotenv').config();
 
 async function main() {
-	const provider = new quais.WebSocketProvider(process.env.WS_RPC_URL);
+	const provider = new quais.WebSocketProvider(process.env.WS_RPC_URL, undefined, { usePathing: true });
 
 	let blockNumber = null;
 	provider.on(

--- a/examples/transactions/send-qi-tx.js
+++ b/examples/transactions/send-qi-tx.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Create wallet and connect to provider
     console.log(process.env.RPC_URL)

--- a/examples/transactions/send-quai-tx.js
+++ b/examples/transactions/send-quai-tx.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Create wallet and connect to provider
     const mnemonic = quais.Mnemonic.fromPhrase(process.env.MNEMONIC);

--- a/examples/wallets/qi-hdwallet.js
+++ b/examples/wallets/qi-hdwallet.js
@@ -3,7 +3,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Create wallet and connect to provider
     const mnemonic = quais.Mnemonic.fromPhrase(process.env.MNEMONIC);

--- a/examples/wallets/qi-send.js
+++ b/examples/wallets/qi-send.js
@@ -3,8 +3,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    console.log('RPC URL: ', process.env.RPC_URL);
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Create Alice's wallet and connect to provider
     const mnemonic = quais.Mnemonic.fromPhrase(process.env.MNEMONIC);

--- a/examples/wallets/qi-wallet-alice-bob-send-receive.js
+++ b/examples/wallets/qi-wallet-alice-bob-send-receive.js
@@ -4,8 +4,7 @@ require('dotenv').config();
 
 async function main() {
 	// Create provider
-	console.log('RPC URL: ', process.env.RPC_URL);
-	const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+	const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
 	// Create wallet and connect to provider
 	const mnemonic = quais.Mnemonic.fromPhrase(process.env.MNEMONIC);

--- a/examples/wallets/qi-wallet-convert-to-quai.js
+++ b/examples/wallets/qi-wallet-convert-to-quai.js
@@ -4,8 +4,7 @@ require('dotenv').config();
 
 async function main() {
     // Create provider
-    console.log('RPC URL: ', process.env.RPC_URL);
-    const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+    const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
     // Create Alice's Qi wallet and connect to provider
     const mnemonic = quais.Mnemonic.fromPhrase(process.env.MNEMONIC);

--- a/examples/wallets/qi-wallet-send-qi-to-bob.js
+++ b/examples/wallets/qi-wallet-send-qi-to-bob.js
@@ -4,8 +4,7 @@ require('dotenv').config();
 
 async function main() {
 	// Create provider
-	console.log('RPC URL: ', process.env.RPC_URL);
-	const provider = new quais.JsonRpcProvider(process.env.RPC_URL);
+	const provider = new quais.JsonRpcProvider(process.env.RPC_URL, undefined, { usePathing: true });
 
 	// Create wallet and connect to provider
 	const mnemonic = quais.Mnemonic.fromPhrase(process.env.MNEMONIC);


### PR DESCRIPTION
Update examples to use the correct provider initialization syntax:
- pass `undefined` for the `NetworkIsh`
- pass the `{ usePathing: true }` arg to the provider