### PR TITLE
Fix buf in  getAddressDetails() method

### DIFF
--- a/examples/utils/get-address-info.js
+++ b/examples/utils/get-address-info.js
@@ -1,21 +1,59 @@
-const quais = require('../../lib/commonjs/quais');
+// Quai SDK Address Info Example
+//
+// This script demonstrates how to use the Quai SDK to:
+//  - Determine if an address is a Qi (UTXO) or Quai (account) address
+//  - Identify the zone/shard for an address
+//  - Extract detailed address information (zone and ledger)
+//
+// The script iterates over a set of example addresses, showing results for each.
 
-// Example address
-const address = '0x002F4783248e2D6FF1aa6482A8C0D7a76de3C329';
+const {
+	isQiAddress,
+	isQuaiAddress,
+	getZoneForAddress,
+	getAddressDetails,
+} = require('../../lib/commonjs/quais');
 
-function main() {
-    // Get zone that address resides in
-    const zone = quais.getZoneForAddress(address);
-    console.log('Address zone: ', zone, '\n');
+// Example addresses for demonstration
+const addresses = [
+	// Quai address in zone 0x00 (ledger bit = 0)
+	'0x0012155ee74cA70C5A68C211B7b8019338C0E5A4',
+	// Quai address in zone 0x01 (ledger bit = 0)
+	'0x0112155ee74cA70C5A68C211B7b8019338C0E5A4',
+	// Qi address in zone 0x00 (ledger bit = 1)
+	'0x00baB97FFA195F6DFA5053F86f84B77C9F795105',
+	// Qi address in zone 0x01 (ledger bit = 1)
+	'0x01d8Dab4dD526ccb38eC10D07169d91C9A4bb657',
+];
 
-    // Get zone and ledger that address resides in
-    const addressDetails = quais.getAddressDetails(address);
-    console.log('Address details: ', addressDetails);
+function printAddressInfo(address) {
+	console.log('----------------------------------------');
+	console.log('Address:', address);
+
+	// 1. Get zone that address resides in
+	const zone = getZoneForAddress(address);
+	console.log('Zone:', zone);
+
+	// 2. Get zone and ledger that address resides in
+	const addressDetails = getAddressDetails(address);
+	console.log('Address Details:', addressDetails);
+
+	// 3. Check if address is a Qi (UTXO) address
+	const isQi = isQiAddress(address);
+	console.log('Is Qi Address:', isQi);
+
+	// 4. Check if address is a Quai (account) address
+	const isQuai = isQuaiAddress(address);
+	console.log('Is Quai Address:', isQuai);
+
+	// Educational note
+	console.log(
+		`This address is in zone ${zone} and is a ${isQi ? 'Qi (UTXO)' : isQuai ? 'Quai (account)' : 'Unknown'} address.\n`
+	);
 }
 
-main()
-    .then(() => process.exit(0))
-    .catch((error) => {
-        console.error(error);
-        process.exit(1);
-    });
+function main() {
+	addresses.forEach(printAddressInfo);
+}
+
+main();

--- a/src/_tests/unit/address-utilities.unit.test.ts
+++ b/src/_tests/unit/address-utilities.unit.test.ts
@@ -1,0 +1,65 @@
+import { isQiAddress, isQuaiAddress, getZoneForAddress, getAddressDetails } from '../../index.js';
+import assert from 'assert';
+
+// Example addresses for testing
+const testCases = [
+    {
+        address: '0x0012155ee74cA70C5A68C211B7b8019338C0E5A4',
+        expected: {
+            zone: '0x00',
+            isQi: false,
+            isQuai: true,
+            ledger: 0, // Quai
+        },
+    },
+    {
+        address: '0x0112155ee74cA70C5A68C211B7b8019338C0E5A4',
+        expected: {
+            zone: '0x01',
+            isQi: false,
+            isQuai: true,
+            ledger: 0, // Quai
+        },
+    },
+    {
+        address: '0x00baB97FFA195F6DFA5053F86f84B77C9F795105',
+        expected: {
+            zone: '0x00',
+            isQi: true,
+            isQuai: false,
+            ledger: 1, // Qi
+        },
+    },
+    {
+        address: '0x01d8Dab4dD526ccb38eC10D07169d91C9A4bb657',
+        expected: {
+            zone: '0x01',
+            isQi: true,
+            isQuai: false,
+            ledger: 1, // Qi
+        },
+    },
+];
+
+describe('Quai SDK Address Utility Functions', function () {
+    testCases.forEach(({ address, expected }) => {
+        it(`correctly identifies zone and ledger for address ${address}`, function () {
+            // Test getZoneForAddress
+            const zone = getZoneForAddress(address);
+            assert.strictEqual(zone, expected.zone, `Zone should be ${expected.zone}`);
+
+            // Test getAddressDetails
+            const details = getAddressDetails(address);
+            assert(details, 'getAddressDetails should not return null');
+            assert.strictEqual(details.zone, expected.zone, `Details.zone should be ${expected.zone}`);
+            assert.strictEqual(details.ledger, expected.ledger, `Ledger should be ${expected.ledger}`);
+        });
+
+        it(`correctly identifies Qi/Quai type for address ${address}`, function () {
+            // Test isQiAddress
+            assert.strictEqual(isQiAddress(address), expected.isQi, `isQiAddress should be ${expected.isQi}`);
+            // Test isQuaiAddress
+            assert.strictEqual(isQuaiAddress(address), expected.isQuai, `isQuaiAddress should be ${expected.isQuai}`);
+        });
+    });
+});

--- a/src/utils/shards.ts
+++ b/src/utils/shards.ts
@@ -35,8 +35,8 @@ type AddressDetails = {
  * @returns {Object | null} An object containing the zone and UTXO information, or null if no address is found.
  */
 export function getAddressDetails(address: string): AddressDetails | null {
-    const isQiLedger = (parseInt(address.substring(4, 5), 16) & 0x1) === Ledger.Qi;
-
+    const thirdNibble = parseInt(address.substring(4, 5), 16);
+    const isQiLedger = (thirdNibble & 0x8) >> 3 === Ledger.Qi;
     return { zone: toZone(address.substring(0, 4)), ledger: isQiLedger ? Ledger.Qi : Ledger.Quai };
 }
 


### PR DESCRIPTION
This PR:
- Fixes a bug in the `getAddressDetails()` utility method
- Adds an example script to showcase wallet utility methods