### PR TITLE
New HD wallet method to fromSeed()

### DIFF
--- a/examples/wallets/create-hdwallets.js
+++ b/examples/wallets/create-hdwallets.js
@@ -1,0 +1,61 @@
+// Quai SDK HD Wallet Creation Example
+//
+// This script demonstrates how to use the Quai SDK to:
+//  - Create HD wallets for both Quai (EVM-based) and Qi (UTXO-based) ledgers
+//  - Instantiate wallets from both a mnemonic phrase and a seed
+//  - Derive addresses for specific accounts and zones
+//
+// The script highlights the difference between mnemonic-based and seed-based wallet instantiation,
+// and shows how to generate addresses for both Quai and Qi ledgers.
+//
+// Educational notes are included throughout to explain key blockchain and wallet concepts.
+
+const {
+	Mnemonic,
+	QuaiHDWallet,
+	QiHDWallet,
+	Zone,
+} = require('../../lib/commonjs/quais');
+require('dotenv').config();
+
+async function main() {
+	// 1. Create a mnemonic from a phrase (typically 12 or 24 words)
+	//    The mnemonic is a human-readable backup for your wallet, as per BIP-39.
+	const mnemonic = Mnemonic.fromPhrase(process.env.MNEMONIC);
+
+	// 2. Create a Quai wallet from a mnemonic
+	//    This uses BIP-44 derivation paths for EVM-based Quai addresses.
+	const quaiWalletFromPhrase = QuaiHDWallet.fromMnemonic(mnemonic);
+	// Derive 1 Quai address for the first account and Cyprus1 zone
+	const quaiAddressFromPhrase = await quaiWalletFromPhrase.getNextAddress(0, Zone.Cyprus1);
+	console.log('quaiAddressFromPhrase: ', quaiAddressFromPhrase);
+
+	// 3. Create a Quai wallet from a seed
+	//    The seed is a binary value derived from the mnemonic (and optional passphrase) using PBKDF2.
+	//    This demonstrates programmatic wallet recovery when only the seed is available.
+	const quaiWalletFromSeed = QuaiHDWallet.fromSeed(mnemonic.computeSeed());
+	const quaiAddressFromSeed = await quaiWalletFromSeed.getNextAddress(0, Zone.Cyprus1);
+	console.log('quaiAddressFromSeed: ', quaiAddressFromSeed);
+
+	// 4. Create a Qi wallet from a mnemonic
+	//    Qi wallets use BIP-44 derivation for UTXO-based addresses, following Quai's sharded architecture.
+	const qiWalletFromPhrase = QiHDWallet.fromMnemonic(mnemonic);
+	const qiAddressFromPhrase = await qiWalletFromPhrase.getNextAddress(0, Zone.Cyprus1);
+	console.log('qiAddressFromPhrase: ', qiAddressFromPhrase);
+
+	// 5. Create a Qi wallet from a seed
+	//    This is useful for interoperability or when only the binary seed is available.
+	const qiWalletFromSeed = QiHDWallet.fromSeed(mnemonic.computeSeed());
+	const qiAddressFromSeed = await qiWalletFromSeed.getNextAddress(0, Zone.Cyprus1);
+	console.log('qiAddressFromSeed: ', qiAddressFromSeed);
+
+	// Educational note:
+	// - QuaiHDWallet is for EVM-based (account model) addresses, while QiHDWallet is for UTXO-based addresses.
+	// - Both support hierarchical deterministic (HD) derivation, allowing you to manage many accounts and addresses from a single root.
+	// - Instantiating from a mnemonic is user-friendly and supports recovery, while instantiating from a seed is useful for programmatic workflows.
+}
+
+main().then(() => process.exit(0)).catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/src/_tests/unit/qihdwallet-address-derivation-from-seed.unit.test.ts
+++ b/src/_tests/unit/qihdwallet-address-derivation-from-seed.unit.test.ts
@@ -1,0 +1,356 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import assert from 'assert';
+import { loadTests } from '../utils.js';
+import { Mnemonic, QiHDWallet, Zone, QiAddressInfo } from '../../index.js';
+
+interface TestCaseQiAddressDerivation {
+    mnemonic: string;
+    externalAddresses: Array<{
+        zone: string;
+        addresses: Array<QiAddressInfo>;
+    }>;
+    changeAddresses: Array<{
+        zone: string;
+        addresses: Array<QiAddressInfo>;
+    }>;
+    paymentCodeAddresses: {
+        bobMnemonic: string;
+        sendAddresses: Array<{
+            zone: string;
+            addresses: Array<QiAddressInfo>;
+        }>;
+        receiveAddresses: Array<{
+            zone: string;
+            addresses: Array<QiAddressInfo>;
+        }>;
+    };
+}
+
+describe('QiHDWallet Address Derivation', function () {
+    this.timeout(2 * 60 * 1000);
+    const tests = loadTests<TestCaseQiAddressDerivation>('qi-address-derivation');
+
+    for (const test of tests) {
+        it('derives external addresses correctly', function () {
+            const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+            const qiWallet = QiHDWallet.fromSeed(mnemonic.computeSeed());
+
+            for (const externalAddressesInfo of test.externalAddresses) {
+                const zone = externalAddressesInfo.zone as Zone;
+                for (const expectedAddressInfo of externalAddressesInfo.addresses) {
+                    const derivedAddressInfo = qiWallet.getNextAddressSync(0, zone);
+                    assert.deepEqual(
+                        derivedAddressInfo,
+                        expectedAddressInfo,
+                        `External address mismatch for zone ${zone}, expected: ${JSON.stringify(expectedAddressInfo, null, 2)}\nderived: ${JSON.stringify(derivedAddressInfo, null, 2)}`,
+                    );
+                }
+            }
+        });
+
+        it('derives change addresses correctly', function () {
+            const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+            const qiWallet = QiHDWallet.fromSeed(mnemonic.computeSeed());
+
+            for (const changeAddressesInfo of test.changeAddresses) {
+                const zone = changeAddressesInfo.zone as Zone;
+                for (const expectedAddressInfo of changeAddressesInfo.addresses) {
+                    const derivedAddressInfo = qiWallet.getNextChangeAddressSync(0, zone);
+                    assert.deepEqual(
+                        derivedAddressInfo,
+                        expectedAddressInfo,
+                        `Change address mismatch for zone ${zone}, expected: ${JSON.stringify(expectedAddressInfo, null, 2)}, derived: ${JSON.stringify(derivedAddressInfo, null, 2)}`,
+                    );
+                }
+            }
+        });
+
+        it('derives payment code send addresses correctly', function () {
+            const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+            const qiWallet = QiHDWallet.fromSeed(mnemonic.computeSeed());
+
+            const bobMnemonic = Mnemonic.fromPhrase(test.paymentCodeAddresses.bobMnemonic);
+            const bobQiWallet = QiHDWallet.fromSeed(bobMnemonic.computeSeed());
+            console.log('getting payment code for Bob...');
+            const bobPaymentCode = bobQiWallet.getPaymentCode(0);
+            console.log('payment code for Bob: ', bobPaymentCode);
+            qiWallet.openChannel(bobPaymentCode);
+            console.log('opened channel for Bob...');
+            for (const sendAddressesInfo of test.paymentCodeAddresses.sendAddresses) {
+                const zone = sendAddressesInfo.zone as Zone;
+                for (const expectedAddressInfo of sendAddressesInfo.addresses) {
+                    const derivedAddressInfo = qiWallet.getNextSendAddress(bobPaymentCode, zone);
+                    assert.deepEqual(
+                        derivedAddressInfo,
+                        expectedAddressInfo,
+                        `Payment code send address mismatch, expected: ${JSON.stringify(expectedAddressInfo, null, 2)}, derived: ${JSON.stringify(derivedAddressInfo, null, 2)}`,
+                    );
+                }
+            }
+        });
+
+        it('derives payment code receive addresses correctly', function () {
+            const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+            const qiWallet = QiHDWallet.fromSeed(mnemonic.computeSeed());
+
+            const bobMnemonic = Mnemonic.fromPhrase(test.paymentCodeAddresses.bobMnemonic);
+            const bobQiWallet = QiHDWallet.fromSeed(bobMnemonic.computeSeed());
+            const bobPaymentCode = bobQiWallet.getPaymentCode(0);
+
+            qiWallet.openChannel(bobPaymentCode);
+
+            for (const receiveAddressesInfo of test.paymentCodeAddresses.receiveAddresses) {
+                const zone = receiveAddressesInfo.zone as Zone;
+                for (const expectedAddressInfo of receiveAddressesInfo.addresses) {
+                    const derivedAddressInfo = qiWallet.getNextReceiveAddress(bobPaymentCode, zone);
+                    assert.deepEqual(
+                        derivedAddressInfo,
+                        expectedAddressInfo,
+                        `Payment code receive address mismatch, expected: ${JSON.stringify(expectedAddressInfo, null, 2)}, derived: ${JSON.stringify(derivedAddressInfo, null, 2)}`,
+                    );
+                }
+            }
+        });
+    }
+});
+
+describe('QiHDWallet Address Getters', function () {
+    this.timeout(2 * 60 * 1000);
+    const tests = loadTests<TestCaseQiAddressDerivation>('qi-address-derivation');
+
+    for (const test of tests) {
+        const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+        const qiWallet = QiHDWallet.fromSeed(mnemonic.computeSeed());
+
+        for (const externalAddressesInfo of test.externalAddresses) {
+            const zone = externalAddressesInfo.zone as Zone;
+            for (const _ of externalAddressesInfo.addresses) {
+                qiWallet.getNextAddressSync(0, zone);
+            }
+        }
+
+        for (const changeAddressesInfo of test.changeAddresses) {
+            const zone = changeAddressesInfo.zone as Zone;
+            for (const _ of changeAddressesInfo.addresses) {
+                qiWallet.getNextChangeAddressSync(0, zone);
+            }
+        }
+
+        const bobMnemonic = Mnemonic.fromPhrase(test.paymentCodeAddresses.bobMnemonic);
+        const bobQiWallet = QiHDWallet.fromSeed(bobMnemonic.computeSeed());
+        const bobPaymentCode = bobQiWallet.getPaymentCode(0);
+        qiWallet.openChannel(bobPaymentCode);
+
+        for (const receiveAddressesInfo of test.paymentCodeAddresses.receiveAddresses) {
+            const zone = receiveAddressesInfo.zone as Zone;
+            for (const _ of receiveAddressesInfo.addresses) {
+                qiWallet.getNextReceiveAddress(bobPaymentCode, zone);
+            }
+        }
+
+        it('getAddressInfo returns correct address info', function () {
+            for (const externalAddressesInfo of test.externalAddresses) {
+                for (const expectedAddressInfo of externalAddressesInfo.addresses) {
+                    const addressInfo = qiWallet.getAddressInfo(expectedAddressInfo.address);
+                    assert.deepEqual(
+                        addressInfo,
+                        expectedAddressInfo,
+                        `External address info mismatch for address ${expectedAddressInfo.address} (got ${JSON.stringify(addressInfo)}, expected ${JSON.stringify(expectedAddressInfo)})`,
+                    );
+                }
+            }
+        });
+
+        it('getChangeAddressInfo returns correct address info', function () {
+            for (const changeAddressesInfo of test.changeAddresses) {
+                for (const expectedAddressInfo of changeAddressesInfo.addresses) {
+                    const addressInfo = qiWallet.getAddressInfo(expectedAddressInfo.address);
+                    assert.deepEqual(
+                        addressInfo,
+                        expectedAddressInfo,
+                        `Change address info mismatch for address ${expectedAddressInfo.address} (got ${JSON.stringify(addressInfo)}, expected ${JSON.stringify(expectedAddressInfo)})`,
+                    );
+                }
+            }
+        });
+
+        it('getAddressesForZone returns all addresses for specified zone', function () {
+            for (const externalAddressesInfo of test.externalAddresses) {
+                const zone = externalAddressesInfo.zone as Zone;
+                const addresses = qiWallet.getAddressesForZone(zone);
+                assert.deepEqual(
+                    addresses,
+                    externalAddressesInfo.addresses,
+                    `External addresses mismatch for zone ${zone} (got ${JSON.stringify(addresses)}, expected ${JSON.stringify(externalAddressesInfo.addresses)})`,
+                );
+            }
+        });
+
+        it('getChangeAddressesForZone returns all change addresses for specified zone', function () {
+            for (const changeAddressesInfo of test.changeAddresses) {
+                const zone = changeAddressesInfo.zone as Zone;
+                const addresses = qiWallet.getChangeAddressesForZone(zone);
+                assert.deepEqual(
+                    addresses,
+                    changeAddressesInfo.addresses,
+                    `Change addresses mismatch for zone ${zone} (got ${JSON.stringify(addresses)}, expected ${JSON.stringify(changeAddressesInfo.addresses)})`,
+                );
+            }
+        });
+
+        it.skip('getPaymentChannelAddressesForZone returns correct addresses', function () {
+            for (const receiveAddressesInfo of test.paymentCodeAddresses.receiveAddresses) {
+                const zone = receiveAddressesInfo.zone as Zone;
+                const addresses = qiWallet.getPaymentChannelAddressesForZone(bobPaymentCode, zone);
+                assert.deepEqual(
+                    addresses,
+                    receiveAddressesInfo.addresses,
+                    `Payment channel addresses mismatch for zone ${zone} (got: ${JSON.stringify(addresses, null, 2)}\nexpected: ${JSON.stringify(receiveAddressesInfo.addresses, null, 2)})`,
+                );
+            }
+        });
+
+        it('getAddressesForAccount returns all addresses for specified account', function () {
+            // Test for account 0 (the one used in test data)
+            const allAddresses = [
+                ...test.externalAddresses.flatMap((info) => info.addresses),
+                ...test.changeAddresses.flatMap((info) => info.addresses),
+                ...test.paymentCodeAddresses.receiveAddresses.flatMap((info) => info.addresses),
+            ].filter((addr) => addr.account === 0);
+
+            const addresses = qiWallet.getAddressesForAccount(0);
+            assert.deepEqual(
+                addresses,
+                allAddresses,
+                `Addresses mismatch for account 0. Got: ${JSON.stringify(addresses, null, 2)}\nExpected: ${JSON.stringify(allAddresses, null, 2)})`,
+            );
+        });
+
+        it('returns empty arrays for non-existent zones and accounts', function () {
+            const nonExistentZone = '0x22' as Zone;
+            const nonExistentAccount = 999;
+
+            assert.deepEqual(qiWallet.getAddressesForZone(nonExistentZone), []);
+            assert.deepEqual(qiWallet.getChangeAddressesForZone(nonExistentZone), []);
+            assert.deepEqual(qiWallet.getPaymentChannelAddressesForZone(bobPaymentCode, nonExistentZone), []);
+            assert.deepEqual(qiWallet.getAddressesForAccount(nonExistentAccount), []);
+        });
+    }
+});
+
+describe('Basic Address Management', function () {
+    const tests = loadTests<TestCaseQiAddressDerivation>('qi-address-derivation');
+
+    for (const test of tests) {
+        const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+        const qiWallet = QiHDWallet.fromSeed(mnemonic.computeSeed());
+
+        it('should add external addresses correctly', function () {
+            // Test with addresses from the first zone in test data
+            const zoneAddresses = test.externalAddresses[0].addresses;
+            const firstAddress = zoneAddresses[0];
+
+            // Add address using the same account and index from test data
+            const addedAddress = qiWallet.addAddress(firstAddress.account, firstAddress.index);
+
+            assert.deepEqual(
+                addedAddress,
+                firstAddress,
+                `Added address does not match expected address for index ${firstAddress.index}`,
+            );
+
+            // Verify the address was added correctly by retrieving it
+            const retrievedAddress = qiWallet.getAddressInfo(firstAddress.address);
+            assert.deepEqual(retrievedAddress, firstAddress, 'Retrieved address does not match added address');
+
+            // Test adding same address index again should throw error
+            assert.throws(
+                () => qiWallet.addAddress(firstAddress.account, firstAddress.index),
+                Error,
+                `Address index ${firstAddress.index} already exists in wallet under path BIP44:external`,
+            );
+        });
+
+        it('should add change addresses correctly', function () {
+            // Test with change addresses from the first zone in test data
+            const zoneChangeAddresses = test.changeAddresses[0].addresses;
+            const firstChangeAddress = zoneChangeAddresses[0];
+
+            // Add change address using the same account and index from test data
+            const addedChangeAddress = qiWallet.addChangeAddress(firstChangeAddress.account, firstChangeAddress.index);
+
+            assert.deepEqual(
+                addedChangeAddress,
+                firstChangeAddress,
+                `Added change address does not match expected address for index ${firstChangeAddress.index}`,
+            );
+
+            // Verify the change address was added correctly by retrieving it
+            const retrievedChangeAddress = qiWallet.getAddressInfo(firstChangeAddress.address);
+            assert.deepEqual(
+                retrievedChangeAddress,
+                firstChangeAddress,
+                'Retrieved change address does not match added change address',
+            );
+
+            // Test adding same change address index again should throw error
+            assert.throws(
+                () => qiWallet.addChangeAddress(firstChangeAddress.account, firstChangeAddress.index),
+                Error,
+                `Address index ${firstChangeAddress.index} already exists in wallet under path BIP44:change`,
+            );
+        });
+
+        it('should handle invalid indices correctly', function () {
+            // Test with negative index
+            assert.throws(() => qiWallet.addAddress(0, -1), Error, 'Negative index should throw error');
+
+            assert.throws(() => qiWallet.addChangeAddress(0, -1), Error, 'Negative index should throw error');
+        });
+
+        it('should handle invalid accounts correctly', function () {
+            // Test with negative account
+            assert.throws(() => qiWallet.addAddress(-1, 0), Error, 'Negative account should throw error');
+
+            assert.throws(() => qiWallet.addChangeAddress(-1, 0), Error, 'Negative account should throw error');
+        });
+
+        it('should reject indices that derive invalid addresses', function () {
+            // For Cyprus1 (0x00) and account 0:
+            // - Index 384 derives an invalid address (wrong zone or ledger)
+            // - Index 385 derives the first valid external address
+            // - Index 4 derives an invalid change address
+            // - Index 5 derives the first valid change address
+
+            // Test invalid external address index
+            assert.throws(
+                () => qiWallet.addAddress(0, 384),
+                Error,
+                'Failed to derive a Qi valid address for the zone 0x00',
+            );
+
+            // Test invalid change address index
+            assert.throws(
+                () => qiWallet.addChangeAddress(0, 4),
+                Error,
+                'Failed to derive a Qi valid address for the zone 0x00',
+            );
+        });
+
+        it('should reject indices that derive duplicate addresses', function () {
+            // Test that adding an existing address index throws error
+            assert.throws(
+                () => qiWallet.addAddress(0, 385),
+                Error,
+                'Address index 385 already exists in wallet under path BIP44:external',
+            );
+
+            // Test that adding an existing change address index throws error
+            assert.throws(
+                () => qiWallet.addChangeAddress(0, 5),
+                Error,
+                'Address index 5 already exists in wallet under path BIP44:change',
+            );
+        });
+    }
+});

--- a/src/_tests/unit/quaihdwallet-address-derivation-from-seed.unit.test.ts
+++ b/src/_tests/unit/quaihdwallet-address-derivation-from-seed.unit.test.ts
@@ -1,0 +1,173 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import assert from 'assert';
+import { loadTests } from '../utils.js';
+import { Mnemonic, QuaiHDWallet, Zone, NeuteredAddressInfo } from '../../index.js';
+
+interface TestCaseQuaiAddressDerivation {
+    mnemonic: string;
+    addresses: Array<{
+        zone: string;
+        account: number;
+        addresses: Array<NeuteredAddressInfo>;
+    }>;
+}
+
+describe('QuaiHDWallet Address Derivation', function () {
+    this.timeout(2 * 60 * 1000);
+    const tests = loadTests<TestCaseQuaiAddressDerivation>('quai-address-derivation');
+
+    for (const test of tests) {
+        it('derives addresses correctly', function () {
+            const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+            const quaiWallet = QuaiHDWallet.fromSeed(mnemonic.computeSeed());
+
+            for (const addressesInfo of test.addresses) {
+                const zone = addressesInfo.zone as Zone;
+                const account = addressesInfo.account;
+
+                for (const expectedAddressInfo of addressesInfo.addresses) {
+                    const derivedAddressInfo = quaiWallet.getNextAddressSync(account, zone);
+                    assert.deepEqual(
+                        derivedAddressInfo,
+                        expectedAddressInfo,
+                        `Address mismatch for zone ${zone}, account ${account}, expected: ${JSON.stringify(expectedAddressInfo)}, derived: ${JSON.stringify(derivedAddressInfo)}`,
+                    );
+                }
+            }
+        });
+    }
+});
+
+describe('QuaiHDWallet Address Getters', function () {
+    this.timeout(2 * 60 * 1000);
+    const tests = loadTests<TestCaseQuaiAddressDerivation>('quai-address-derivation');
+
+    for (const test of tests) {
+        const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+        const quaiWallet = QuaiHDWallet.fromSeed(mnemonic.computeSeed());
+
+        // Generate all addresses first
+        for (const addressesInfo of test.addresses) {
+            const zone = addressesInfo.zone as Zone;
+            const account = addressesInfo.account;
+            for (const _ of addressesInfo.addresses) {
+                quaiWallet.getNextAddressSync(account, zone);
+            }
+        }
+
+        it('getAddressInfo returns correct address info', function () {
+            for (const addressesInfo of test.addresses) {
+                for (const expectedAddressInfo of addressesInfo.addresses) {
+                    const addressInfo = quaiWallet.getAddressInfo(expectedAddressInfo.address);
+                    assert.deepEqual(
+                        addressInfo,
+                        expectedAddressInfo,
+                        `Address info mismatch for address ${expectedAddressInfo.address}`,
+                    );
+                }
+            }
+        });
+
+        it('getAddressesForZone returns all addresses for specified zone', function () {
+            for (const addressesInfo of test.addresses) {
+                const zone = addressesInfo.zone as Zone;
+                const addresses = quaiWallet.getAddressesForZone(zone);
+                const expectedAddresses = test.addresses
+                    .filter((info) => info.zone === zone)
+                    .flatMap((info) => info.addresses);
+
+                assert.deepEqual(addresses, expectedAddresses, `Addresses mismatch for zone ${zone}`);
+            }
+        });
+
+        it('getAddressesForAccount returns all addresses for specified account', function () {
+            const accountMap = new Map<number, NeuteredAddressInfo[]>();
+
+            // Group expected addresses by account
+            for (const addressesInfo of test.addresses) {
+                const account = addressesInfo.account;
+                if (!accountMap.has(account)) {
+                    accountMap.set(account, []);
+                }
+                accountMap.get(account)!.push(...addressesInfo.addresses);
+            }
+
+            // Test each account
+            for (const [account, expectedAddresses] of accountMap) {
+                const addresses = quaiWallet.getAddressesForAccount(account);
+                assert.deepEqual(addresses, expectedAddresses, `Addresses mismatch for account ${account}`);
+            }
+        });
+
+        it('returns empty arrays for non-existent zones and accounts', function () {
+            const nonExistentZone = '0x22' as Zone;
+            const nonExistentAccount = 999;
+
+            assert.deepEqual(quaiWallet.getAddressesForZone(nonExistentZone), []);
+            assert.deepEqual(quaiWallet.getAddressesForAccount(nonExistentAccount), []);
+        });
+    }
+});
+
+describe('Basic Address Management', function () {
+    const tests = loadTests<TestCaseQuaiAddressDerivation>('quai-address-derivation');
+
+    for (const test of tests) {
+        const mnemonic = Mnemonic.fromPhrase(test.mnemonic);
+        const quaiWallet = QuaiHDWallet.fromSeed(mnemonic.computeSeed());
+
+        it('should add addresses correctly', function () {
+            // Test with addresses from the first zone/account in test data
+            const firstZoneAddresses = test.addresses[0].addresses;
+            const firstAddress = firstZoneAddresses[0];
+
+            // Add address using the same account and index from test data
+            const addedAddress = quaiWallet.addAddress(firstAddress.account, firstAddress.index);
+
+            assert.deepEqual(
+                addedAddress,
+                firstAddress,
+                `Added address does not match expected address for index ${firstAddress.index}`,
+            );
+
+            // Verify the address was added correctly by retrieving it
+            const retrievedAddress = quaiWallet.getAddressInfo(firstAddress.address);
+            assert.deepEqual(retrievedAddress, firstAddress, 'Retrieved address does not match added address');
+
+            // Test adding same address index again should throw error
+            assert.throws(
+                () => quaiWallet.addAddress(firstAddress.account, firstAddress.index),
+                Error,
+                `Address for index ${firstAddress.index} already exists`,
+            );
+        });
+
+        it('should handle invalid indices correctly', function () {
+            // Test with negative index
+            assert.throws(() => quaiWallet.addAddress(0, -1), Error, 'Negative index should throw error');
+        });
+
+        it('should handle invalid accounts correctly', function () {
+            // Test with negative account
+            assert.throws(() => quaiWallet.addAddress(-1, 0), Error, 'Negative account should throw error');
+        });
+
+        it('should reject indices that derive invalid addresses', function () {
+            // For Cyprus1 (0x00) and account 0:
+            // Index 518 derives an invalid address (wrong zone or ledger)
+            // Index 519 derives the first valid address
+
+            // Test invalid address index
+            assert.throws(
+                () => quaiWallet.addAddress(0, 518),
+                Error,
+                'Failed to derive a valid address zone for the index 518',
+            );
+        });
+
+        it('should reject indices that derive duplicate addresses', function () {
+            // Test that adding an existing address index throws error
+            assert.throws(() => quaiWallet.addAddress(0, 519), Error, 'Address for index 519 already exists');
+        });
+    }
+});


### PR DESCRIPTION
Changes introduced by this PR:
- Exposes a new static method for `QiHDWallet` and `QuaiHDWallet` to instantiate a new wallet object from a BIP39 seed:

```javascript
	//    The mnemonic is a human-readable backup for your wallet, as per BIP-39.
	const mnemonic = Mnemonic.fromPhrase(process.env.MNEMONIC);
	
        //  Create a Quai wallet from a seed
	const quaiWalletFromSeed = QuaiHDWallet.fromSeed(mnemonic.computeSeed());
	const quaiAddressFromSeed = await quaiWalletFromSeed.getNextAddress(0, Zone.Cyprus1);
	console.log('quaiAddressFromSeed: ', quaiAddressFromSeed);

	//  Create a Qi wallet from a seed
	const qiWalletFromSeed = QiHDWallet.fromSeed(mnemonic.computeSeed());
	const qiAddressFromSeed = await qiWalletFromSeed.getNextAddress(0, Zone.Cyprus1);
	console.log('qiAddressFromSeed: ', qiAddressFromSeed);
```

- Add unit tests to validate addresses generated by wallets instantiated from a seed
- Add a example script (i.e. `examples/create-hdwallets.js`) to ilustrate the different use cases